### PR TITLE
refactor: centralize Restic configuration into service

### DIFF
--- a/list_snapshot_files.py
+++ b/list_snapshot_files.py
@@ -1,36 +1,20 @@
 import os
 import subprocess
 import sys
-from dotenv import load_dotenv
 
-# === 1. Carregar variáveis do .env ===
-load_dotenv()
+from services.restic import load_restic_env
 
-# === 2. Determinar provedor e montar o RESTIC_REPOSITORY ===
-PROVIDER = os.getenv("STORAGE_PROVIDER", "").lower()
-BUCKET = os.getenv("STORAGE_BUCKET", "")
-RESTIC_PASSWORD = os.getenv("RESTIC_PASSWORD")
-
-if PROVIDER == "aws":
-    RESTIC_REPOSITORY = f"s3:s3.amazonaws.com/{BUCKET}"
-elif PROVIDER == "azure":
-    RESTIC_REPOSITORY = f"azure:{BUCKET}:restic"
-elif PROVIDER == "gcp":
-    RESTIC_REPOSITORY = f"gs:{BUCKET}"
-else:
-    print("[FATAL] STORAGE_PROVIDER inválido ou não definido. Use 'aws', 'azure' ou 'gcp'")
+# === 1. Carregar configurações do Restic ===
+try:
+    RESTIC_REPOSITORY, env, _ = load_restic_env()
+except ValueError as e:
+    print(f"[FATAL] {e}")
     sys.exit(1)
 
-# === 3. Validar variáveis obrigatórias ===
-if not RESTIC_REPOSITORY or not RESTIC_PASSWORD:
-    print("[FATAL] RESTIC_REPOSITORY e RESTIC_PASSWORD precisam estar definidos corretamente.")
-    sys.exit(1)
-
-# === 4. Obter o snapshot ID da linha de comando (ou usar 'latest') ===
+# === 2. Obter o snapshot ID da linha de comando (ou usar 'latest') ===
 SNAPSHOT_ID = sys.argv[1] if len(sys.argv) > 1 else "latest"
 
-# === 5. Executar o comando restic ls para listar os arquivos do snapshot ===
-env = os.environ.copy()
+# === 3. Executar o comando restic ls para listar os arquivos do snapshot ===
 
 print(f"📂 Listando arquivos do snapshot '{SNAPSHOT_ID}'...")
 

--- a/list_snapshots.py
+++ b/list_snapshots.py
@@ -1,33 +1,14 @@
 import os
 import subprocess
-from dotenv import load_dotenv
 
-# === 1. CARREGAR VARIÁVEIS DO .ENV ===
-load_dotenv()
+from services.restic import load_restic_env
 
-# === 2. DETERMINAR PROVEDOR E MONTAR O RESTIC_REPOSITORY ===
-PROVIDER = os.getenv("STORAGE_PROVIDER", "").lower()
-BUCKET = os.getenv("STORAGE_BUCKET", "")
-RESTIC_PASSWORD = os.getenv("RESTIC_PASSWORD")
-
-# Montagem do repositório com base no provedor de nuvem
-if PROVIDER == "aws":
-    RESTIC_REPOSITORY = f"s3:s3.amazonaws.com/{BUCKET}"
-elif PROVIDER == "azure":
-    RESTIC_REPOSITORY = f"azure:{BUCKET}:restic"
-elif PROVIDER == "gcp":
-    RESTIC_REPOSITORY = f"gs:{BUCKET}"
-else:
-    print("[FATAL] STORAGE_PROVIDER inválido. Use 'aws', 'azure' ou 'gcp'")
+# === 1. Carregar configurações do Restic ===
+try:
+    RESTIC_REPOSITORY, env, _ = load_restic_env()
+except ValueError as e:
+    print(f"[FATAL] {e}")
     exit(1)
-
-# === 3. VERIFICAÇÃO DE VARIÁVEIS OBRIGATÓRIAS ===
-if not RESTIC_REPOSITORY or not RESTIC_PASSWORD:
-    print("[FATAL] RESTIC_REPOSITORY e RESTIC_PASSWORD precisam estar definidos no .env")
-    exit(1)
-
-# Copia o ambiente (incluindo variáveis carregadas)
-env = os.environ.copy()
 
 # === 4. EXECUTAR O COMANDO RESTIC PARA LISTAR SNAPSHOTS ===
 print(f"istando snapshots do repositório: {RESTIC_REPOSITORY}\n")

--- a/list_snapshots_with_size.py
+++ b/list_snapshots_with_size.py
@@ -1,34 +1,15 @@
 import os
 import subprocess
 import json
-from dotenv import load_dotenv
 
-# === 1. CARREGAR VARIÁVEIS DO .ENV ===
-load_dotenv()
+from services.restic import load_restic_env
 
-# === 2. DETERMINAR PROVEDOR E MONTAR O RESTIC_REPOSITORY ===
-PROVIDER = os.getenv("STORAGE_PROVIDER", "").lower()
-BUCKET = os.getenv("STORAGE_BUCKET", "")
-RESTIC_PASSWORD = os.getenv("RESTIC_PASSWORD")
-
-# Montagem do repositório com base no provedor de nuvem
-if PROVIDER == "aws":
-    RESTIC_REPOSITORY = f"s3:s3.amazonaws.com/{BUCKET}"
-elif PROVIDER == "azure":
-    RESTIC_REPOSITORY = f"azure:{BUCKET}:restic"
-elif PROVIDER == "gcp":
-    RESTIC_REPOSITORY = f"gs:{BUCKET}"
-else:
-    print("[FATAL] STORAGE_PROVIDER inválido. Use 'aws', 'azure' ou 'gcp'")
+# === 1. Carregar configurações do Restic ===
+try:
+    RESTIC_REPOSITORY, env, _ = load_restic_env()
+except ValueError as e:
+    print(f"[FATAL] {e}")
     exit(1)
-
-# === 3. VERIFICAÇÃO DE VARIÁVEIS OBRIGATÓRIAS ===
-if not RESTIC_REPOSITORY or not RESTIC_PASSWORD:
-    print("[FATAL] RESTIC_REPOSITORY e RESTIC_PASSWORD precisam estar definidos no .env")
-    exit(1)
-
-# Copia o ambiente (incluindo variáveis carregadas)
-env = os.environ.copy()
 
 # === 4. Buscar todos os snapshots em JSON ===
 try:

--- a/repository_stats.py
+++ b/repository_stats.py
@@ -1,30 +1,16 @@
-# repository_stats.py
+"""Exibe estatísticas do repositório Restic."""
+
 import os
 import subprocess
 import json
-from dotenv import load_dotenv
 
-load_dotenv()
+from services.restic import load_restic_env
 
-PROVIDER = os.getenv("STORAGE_PROVIDER", "").lower()
-BUCKET = os.getenv("STORAGE_BUCKET", "")
-RESTIC_PASSWORD = os.getenv("RESTIC_PASSWORD")
-
-if PROVIDER == "aws":
-    RESTIC_REPOSITORY = f"s3:s3.amazonaws.com/{BUCKET}"
-elif PROVIDER == "azure":
-    RESTIC_REPOSITORY = f"azure:{BUCKET}:restic"
-elif PROVIDER == "gcp":
-    RESTIC_REPOSITORY = f"gs:{BUCKET}"
-else:
-    print("[FATAL] STORAGE_PROVIDER inválido.")
+try:
+    RESTIC_REPOSITORY, env, _ = load_restic_env()
+except ValueError as e:
+    print(f"[FATAL] {e}")
     exit(1)
-
-if not RESTIC_REPOSITORY or not RESTIC_PASSWORD:
-    print("[FATAL] Variáveis obrigatórias ausentes.")
-    exit(1)
-
-env = os.environ.copy()
 
 print(f" Obtendo estatísticas gerais do repositório: {RESTIC_REPOSITORY}\n")
 

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,2 @@
+"""Utilities for Safestic scripts."""
+

--- a/services/restic.py
+++ b/services/restic.py
@@ -1,0 +1,46 @@
+"""Helper functions for loading Restic configuration."""
+
+from __future__ import annotations
+
+import os
+from dotenv import load_dotenv
+
+
+def load_restic_env() -> tuple[str, dict[str, str], str]:
+    """Load environment variables and build the Restic repository string.
+
+    Returns
+    -------
+    tuple[str, dict[str, str], str]
+        A tuple containing the repository URL, a copy of the environment
+        variables and the provider name.
+
+    Raises
+    ------
+    ValueError
+        If required variables are missing or the provider is invalid.
+    """
+
+    load_dotenv()
+
+    provider = os.getenv("STORAGE_PROVIDER", "").lower()
+    bucket = os.getenv("STORAGE_BUCKET", "")
+    password = os.getenv("RESTIC_PASSWORD")
+
+    if provider == "aws":
+        repository = f"s3:s3.amazonaws.com/{bucket}"
+    elif provider == "azure":
+        repository = f"azure:{bucket}:restic"
+    elif provider == "gcp":
+        repository = f"gs:{bucket}"
+    else:
+        raise ValueError("STORAGE_PROVIDER inválido. Use 'aws', 'azure' ou 'gcp'")
+
+    if not repository or not password:
+        raise ValueError(
+            "RESTIC_REPOSITORY e RESTIC_PASSWORD precisam estar definidos no .env"
+        )
+
+    env = os.environ.copy()
+    return repository, env, provider
+


### PR DESCRIPTION
## Summary
- add reusable `load_restic_env` service to construct repository URL and environment
- refactor all Restic scripts to use the new service and drop duplicated setup code

## Testing
- `python -m py_compile *.py services/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6893948e7c58832a847e575615a62596