### PR TITLE
feat: expand detailed logging across scripts

### DIFF
--- a/check_restic_access.py
+++ b/check_restic_access.py
@@ -1,8 +1,8 @@
 import os
-import subprocess
 import sys
 
 from services.restic import load_restic_env
+from services.logger import create_log_file, log, run_cmd
 
 # === 1. Carregar configurações do Restic ===
 try:
@@ -14,59 +14,67 @@ except ValueError as e:
 RESTIC_PASSWORD = os.getenv("RESTIC_PASSWORD")
 
 # === 3. Verificar variáveis obrigatórias ===
+LOG_DIR = os.getenv("LOG_DIR", "logs")
+LOG_FILE = create_log_file("check_restic_access", LOG_DIR)
+
 print("🔍 Verificando variáveis essenciais do .env")
-def print_status(name, result):
-    print(f"{name.ljust(30)}: {'OK' if result else '❌ FALHA'}")
+with open(LOG_FILE, "w", encoding="utf-8") as log_file:
+    def print_status(name, result):
+        line = f"{name.ljust(30)}: {'OK' if result else '❌ FALHA'}"
+        print(line)
+        log(line, log_file)
 
-print_status("RESTIC_REPOSITORY", bool(RESTIC_REPOSITORY))
-print_status("RESTIC_PASSWORD", bool(RESTIC_PASSWORD))
+    print_status("RESTIC_REPOSITORY", bool(RESTIC_REPOSITORY))
+    print_status("RESTIC_PASSWORD", bool(RESTIC_PASSWORD))
 
-if PROVIDER == "aws":
-    print_status("AWS_ACCESS_KEY_ID", bool(os.getenv("AWS_ACCESS_KEY_ID")))
-    print_status("AWS_SECRET_ACCESS_KEY", bool(os.getenv("AWS_SECRET_ACCESS_KEY")))
-elif PROVIDER == "azure":
-    print_status("AZURE_ACCOUNT_NAME", bool(os.getenv("AZURE_ACCOUNT_NAME")))
-    print_status("AZURE_ACCOUNT_KEY", bool(os.getenv("AZURE_ACCOUNT_KEY")))
-elif PROVIDER == "gcp":
-    print_status("GOOGLE_PROJECT_ID", bool(os.getenv("GOOGLE_PROJECT_ID")))
-    print_status("GOOGLE_APPLICATION_CREDENTIALS", bool(os.getenv("GOOGLE_APPLICATION_CREDENTIALS")))
+    if PROVIDER == "aws":
+        print_status("AWS_ACCESS_KEY_ID", bool(os.getenv("AWS_ACCESS_KEY_ID")))
+        print_status("AWS_SECRET_ACCESS_KEY", bool(os.getenv("AWS_SECRET_ACCESS_KEY")))
+    elif PROVIDER == "azure":
+        print_status("AZURE_ACCOUNT_NAME", bool(os.getenv("AZURE_ACCOUNT_NAME")))
+        print_status("AZURE_ACCOUNT_KEY", bool(os.getenv("AZURE_ACCOUNT_KEY")))
+    elif PROVIDER == "gcp":
+        print_status("GOOGLE_PROJECT_ID", bool(os.getenv("GOOGLE_PROJECT_ID")))
+        print_status("GOOGLE_APPLICATION_CREDENTIALS", bool(os.getenv("GOOGLE_APPLICATION_CREDENTIALS")))
 
-if not RESTIC_REPOSITORY or not RESTIC_PASSWORD:
-    print("\n[FATAL] Variáveis obrigatórias estão ausentes. Abortando.")
-    sys.exit(1)
-
-# === 4. Verificar se Restic está no PATH ===
-print("\nVerificando se 'restic' está disponível no PATH...")
-try:
-    subprocess.run(["restic", "version"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    print("Restic está instalado e acessível.")
-except FileNotFoundError:
-    print("Restic não encontrado no PATH.")
-    sys.exit(1)
-except subprocess.CalledProcessError as e:
-    print("Restic executou com erro:", e)
-    sys.exit(1)
-
-# === 5. Testar acesso ao repositório ===
-print("\nTestando acesso ao repositório...")
-try:
-    subprocess.run(
-        ["restic", "-r", RESTIC_REPOSITORY, "snapshots"],
-        env=env,
-        check=True
-    )
-    print("Acesso ao repositório bem-sucedido.")
-except subprocess.CalledProcessError as e:
-    print("Não foi possível acessar o repositório.")
-    print("Tentando inicializar...")
-
-    try:
-        subprocess.run(
-            ["restic", "-r", RESTIC_REPOSITORY, "init"],
-            env=env,
-            check=True
-        )
-        print("Repositório foi inicializado com sucesso!")
-    except subprocess.CalledProcessError:
-        print("Falha ao inicializar o repositório.")
+    if not RESTIC_REPOSITORY or not RESTIC_PASSWORD:
+        log("[FATAL] Variáveis obrigatórias estão ausentes. Abortando.", log_file)
+        print("\n[FATAL] Variáveis obrigatórias estão ausentes. Abortando.")
         sys.exit(1)
+
+    # === 4. Verificar se Restic está no PATH ===
+    log("\nVerificando se 'restic' está disponível no PATH...", log_file)
+    success, _ = run_cmd(
+        ["restic", "version"],
+        log_file,
+        error_msg="Restic não encontrado ou com erro",
+    )
+    if not success:
+        sys.exit(1)
+    log("Restic está instalado e acessível.", log_file)
+    print("Restic está instalado e acessível.")
+
+    # === 5. Testar acesso ao repositório ===
+    log("\nTestando acesso ao repositório...", log_file)
+    success, _ = run_cmd(
+        ["restic", "-r", RESTIC_REPOSITORY, "snapshots"],
+        log_file,
+        env=env,
+        error_msg="Não foi possível acessar o repositório",
+    )
+    if success:
+        log("Acesso ao repositório bem-sucedido.", log_file)
+        print("Acesso ao repositório bem-sucedido.")
+    else:
+        print("Não foi possível acessar o repositório.")
+        log("Tentando inicializar...", log_file)
+
+        success, _ = run_cmd(
+            ["restic", "-r", RESTIC_REPOSITORY, "init"],
+            log_file,
+            env=env,
+            error_msg="Falha ao inicializar o repositório",
+            success_msg="Repositório foi inicializado com sucesso!",
+        )
+        if not success:
+            sys.exit(1)

--- a/list_snapshots_with_size.py
+++ b/list_snapshots_with_size.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
-import subprocess
+import os
 import sys
 
 from services.restic import load_restic_env
+from services.logger import create_log_file, log, run_cmd
 
 
 def list_snapshots_with_size() -> None:
@@ -18,29 +19,33 @@ def list_snapshots_with_size() -> None:
         print(f"[FATAL] {exc}")
         sys.exit(1)
 
-    try:
-        result = subprocess.run(
+    log_dir = os.getenv("LOG_DIR", "logs")
+    log_filename = create_log_file("list_snapshots_with_size", log_dir)
+
+    with open(log_filename, "w", encoding="utf-8") as log_file:
+        success, result = run_cmd(
             ["restic", "-r", repository, "snapshots", "--json"],
+            log_file,
             env=env,
-            capture_output=True,
-            check=True,
-            text=True,
+            error_msg="Falha ao buscar snapshots",
         )
-        snapshots = json.loads(result.stdout)
-    except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
-        print(f"[FATAL] Falha ao buscar snapshots: {exc}")
-        sys.exit(1)
-
-    print(f"Listando snapshots do repositório: {repository}\n")
-
-    for snap in snapshots:
-        short_id = snap["short_id"]
-        time = snap["time"]
-        hostname = snap["hostname"]
-        paths = ", ".join(snap["paths"])
-
+        if not success or result is None:
+            sys.exit(1)
         try:
-            stats_result = subprocess.run(
+            snapshots = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            log(f"Erro ao decodificar JSON: {exc}", log_file)
+            sys.exit(1)
+
+        log(f"Listando snapshots do repositório: {repository}\n", log_file)
+
+        for snap in snapshots:
+            short_id = snap["short_id"]
+            time = snap["time"]
+            hostname = snap["hostname"]
+            paths = ", ".join(snap["paths"])
+
+            success, stats_res = run_cmd(
                 [
                     "restic",
                     "-r",
@@ -51,20 +56,29 @@ def list_snapshots_with_size() -> None:
                     "restore-size",
                     "--json",
                 ],
+                log_file,
                 env=env,
-                capture_output=True,
-                check=True,
-                text=True,
+                error_msg="Erro ao calcular tamanho",
             )
-            stats = json.loads(stats_result.stdout)
-            total_bytes = stats.get("total_size", 0)
-            total_gib = total_bytes / (1024 ** 3)
-            print(f"{short_id} | {time} | {hostname} | {paths} | {total_gib:.3f} GiB")
-        except (subprocess.CalledProcessError, json.JSONDecodeError):
-            print(
-                f"{short_id} | {time} | {hostname} | {paths} | (erro ao calcular tamanho)"
-            )
+
+            if success and stats_res is not None:
+                try:
+                    stats = json.loads(stats_res.stdout)
+                    total_bytes = stats.get("total_size", 0)
+                    total_gib = total_bytes / (1024 ** 3)
+                    print(
+                        f"{short_id} | {time} | {hostname} | {paths} | {total_gib:.3f} GiB"
+                    )
+                except json.JSONDecodeError:
+                    print(
+                        f"{short_id} | {time} | {hostname} | {paths} | (erro ao calcular tamanho)"
+                    )
+            else:
+                print(
+                    f"{short_id} | {time} | {hostname} | {paths} | (erro ao calcular tamanho)"
+                )
 
 
 if __name__ == "__main__":
     list_snapshots_with_size()
+

--- a/manual_prune.py
+++ b/manual_prune.py
@@ -1,8 +1,8 @@
 import os
-import subprocess
 import sys
 
 from services.restic import load_restic_env
+from services.logger import create_log_file, log, run_cmd
 
 # === 1. Carregar configurações do Restic ===
 try:
@@ -11,32 +11,47 @@ except ValueError as e:
     print(f"[FATAL] {e}")
     sys.exit(1)
 
+LOG_DIR = os.getenv("LOG_DIR", "logs")
+log_filename = create_log_file("manual_prune", LOG_DIR)
+
 # === 2. Coletar políticas de retenção do .env ou usar defaults ===
 RETENTION_KEEP_DAILY = os.getenv("RETENTION_KEEP_DAILY", "7")
 RETENTION_KEEP_WEEKLY = os.getenv("RETENTION_KEEP_WEEKLY", "4")
 RETENTION_KEEP_MONTHLY = os.getenv("RETENTION_KEEP_MONTHLY", "6")
 
-print("Aplicando política de retenção manual:")
-print(f"  Diário:   {RETENTION_KEEP_DAILY}")
-print(f"  Semanal:  {RETENTION_KEEP_WEEKLY}")
-print(f"  Mensal:   {RETENTION_KEEP_MONTHLY}")
-print()
 
-# === 3. Executar comando restic forget --prune ===
+def main() -> None:
+    with open(log_filename, "w", encoding="utf-8") as log_file:
+        log("Aplicando política de retenção manual:", log_file)
+        log(f"  Diário:   {RETENTION_KEEP_DAILY}", log_file)
+        log(f"  Semanal:  {RETENTION_KEEP_WEEKLY}", log_file)
+        log(f"  Mensal:   {RETENTION_KEEP_MONTHLY}", log_file)
 
-try:
-    subprocess.run(
-        [
-            "restic", "-r", RESTIC_REPOSITORY, "forget",
-            "--keep-daily", RETENTION_KEEP_DAILY,
-            "--keep-weekly", RETENTION_KEEP_WEEKLY,
-            "--keep-monthly", RETENTION_KEEP_MONTHLY,
-            "--prune"
-        ],
-        env=env,
-        check=True
-    )
-    print("Política de retenção aplicada com sucesso.")
-except subprocess.CalledProcessError:
-    print("Erro ao aplicar política de retenção.")
-    sys.exit(1)
+        cmd = [
+            "restic",
+            "-r",
+            RESTIC_REPOSITORY,
+            "forget",
+            "--keep-daily",
+            RETENTION_KEEP_DAILY,
+            "--keep-weekly",
+            RETENTION_KEEP_WEEKLY,
+            "--keep-monthly",
+            RETENTION_KEEP_MONTHLY,
+            "--prune",
+        ]
+
+        success, _ = run_cmd(
+            cmd,
+            log_file,
+            env=env,
+            success_msg="Política de retenção aplicada com sucesso.",
+            error_msg="Erro ao aplicar política de retenção.",
+        )
+
+        if not success:
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/repository_stats.py
+++ b/repository_stats.py
@@ -1,12 +1,13 @@
-"""Display basic statistics from the configured Restic repository."""
+"""Show overall size information about the Restic repository."""
 
 from __future__ import annotations
 
 import json
-import subprocess
+import os
 import sys
 
 from services.restic import load_restic_env
+from services.logger import create_log_file, log, run_cmd
 
 
 def show_repository_stats() -> None:
@@ -18,10 +19,13 @@ def show_repository_stats() -> None:
         print(f"[FATAL] {exc}")
         sys.exit(1)
 
-    print(f"Obtendo estatísticas gerais do repositório: {repository}\n")
+    log_dir = os.getenv("LOG_DIR", "logs")
+    log_filename = create_log_file("repository_stats", log_dir)
 
-    try:
-        result = subprocess.run(
+    with open(log_filename, "w", encoding="utf-8") as log_file:
+        log(f"Obtendo estatísticas gerais do repositório: {repository}\n", log_file)
+
+        success, result = run_cmd(
             [
                 "restic",
                 "-r",
@@ -31,21 +35,26 @@ def show_repository_stats() -> None:
                 "raw-data",
                 "--json",
             ],
+            log_file,
             env=env,
-            capture_output=True,
-            check=True,
-            text=True,
+            error_msg="Falha ao obter estatísticas",
         )
-        stats = json.loads(result.stdout)
+        if not success or result is None:
+            sys.exit(1)
+
+        try:
+            stats = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            log(f"Erro ao decodificar JSON: {exc}", log_file)
+            sys.exit(1)
+
         size_bytes = stats.get("total_size", 0)
         size_gib = size_bytes / (1024 ** 3)
         print(
-            f"Tamanho total armazenado no repositório (dados únicos): {size_gib:.3f} GiB"
+            f"Tamanho total armazenado no repositório (dados únicos): {size_gib:.3f} GiB",
         )
-    except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
-        print(f"[ERRO] Falha ao obter estatísticas: {exc}")
-        sys.exit(1)
 
 
 if __name__ == "__main__":
     show_repository_stats()
+


### PR DESCRIPTION
## Summary
- centralize command execution logging in `services.logger.run_cmd`
- add detailed log output to backup, restore, listing, pruning and diagnostic scripts

## Testing
- `python -m py_compile check_restic_access.py list_snapshot_files.py list_snapshots.py list_snapshots_with_size.py manual_prune.py repository_stats.py restic_backup.py restore_file.py restore_snapshot.py services/logger.py`


------
https://chatgpt.com/codex/tasks/task_e_689635fb6e5c832a9336938d3b926def