### PR TITLE
Refactor script initialization and CLI handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ifndef ID
 	$(error Voce precisa passar o ID do snapshot: make list-files ID=abc123)
 endif
 	@echo "Listando arquivos do snapshot ID=$(ID)..."
-	$(PYTHON) list_snapshot_files.py $(ID)
+$(PYTHON) list_snapshot_files.py --id $(ID)
 
 ## Restaura o snapshot mais recente (default = latest)
 restore:
@@ -43,7 +43,7 @@ ifndef ID
 	$(error Voce precisa passar o ID do snapshot: make restore-id ID=abc123)
 endif
 	@echo "Restaurando snapshot ID=$(ID)..."
-	$(PYTHON) restore_snapshot.py $(ID)
+$(PYTHON) restore_snapshot.py --id $(ID)
 
 ## Restaura arquivo especifico (ex: make restore-file ID=abc123 FILE=/etc/hosts)
 restore-file:
@@ -54,7 +54,7 @@ ifndef FILE
 	$(error Voce precisa passar o caminho do arquivo: make restore-file ID=abc123 FILE=/caminho)
 endif
 	@echo "Restaurando arquivo $(FILE) do snapshot ID=$(ID)..."
-	$(PYTHON) restore_file.py $(ID) $(FILE)
+$(PYTHON) restore_file.py --id $(ID) --path $(FILE)
 
 ## Aplica retencao manual usando o script Python dedicado
 manual-prune:

--- a/check_restic_access.py
+++ b/check_restic_access.py
@@ -1,80 +1,73 @@
 import os
 import sys
 
-from services.restic import load_restic_env
-from services.logger import create_log_file, log, run_cmd
+from services.script import ResticScript
 
-# === 1. Carregar configurações do Restic ===
-try:
-    RESTIC_REPOSITORY, env, PROVIDER = load_restic_env()
-except ValueError as e:
-    print(f"[FATAL] {e}")
-    sys.exit(1)
 
-RESTIC_PASSWORD = os.getenv("RESTIC_PASSWORD")
+def main() -> None:
+    with ResticScript("check_restic_access") as ctx:
+        restic_password = os.getenv("RESTIC_PASSWORD")
 
-# === 3. Verificar variáveis obrigatórias ===
-LOG_DIR = os.getenv("LOG_DIR", "logs")
-LOG_FILE = create_log_file("check_restic_access", LOG_DIR)
+        print("🔍 Verificando variáveis essenciais do .env")
 
-print("🔍 Verificando variáveis essenciais do .env")
-with open(LOG_FILE, "w", encoding="utf-8") as log_file:
-    def print_status(name, result):
-        line = f"{name.ljust(30)}: {'OK' if result else '❌ FALHA'}"
-        print(line)
-        log(line, log_file)
+        def print_status(name: str, result: bool) -> None:
+            line = f"{name.ljust(30)}: {'OK' if result else '❌ FALHA'}"
+            print(line)
+            ctx.log(line)
 
-    print_status("RESTIC_REPOSITORY", bool(RESTIC_REPOSITORY))
-    print_status("RESTIC_PASSWORD", bool(RESTIC_PASSWORD))
+        print_status("RESTIC_REPOSITORY", bool(ctx.repository))
+        print_status("RESTIC_PASSWORD", bool(restic_password))
 
-    if PROVIDER == "aws":
-        print_status("AWS_ACCESS_KEY_ID", bool(os.getenv("AWS_ACCESS_KEY_ID")))
-        print_status("AWS_SECRET_ACCESS_KEY", bool(os.getenv("AWS_SECRET_ACCESS_KEY")))
-    elif PROVIDER == "azure":
-        print_status("AZURE_ACCOUNT_NAME", bool(os.getenv("AZURE_ACCOUNT_NAME")))
-        print_status("AZURE_ACCOUNT_KEY", bool(os.getenv("AZURE_ACCOUNT_KEY")))
-    elif PROVIDER == "gcp":
-        print_status("GOOGLE_PROJECT_ID", bool(os.getenv("GOOGLE_PROJECT_ID")))
-        print_status("GOOGLE_APPLICATION_CREDENTIALS", bool(os.getenv("GOOGLE_APPLICATION_CREDENTIALS")))
+        if ctx.provider == "aws":
+            print_status("AWS_ACCESS_KEY_ID", bool(os.getenv("AWS_ACCESS_KEY_ID")))
+            print_status(
+                "AWS_SECRET_ACCESS_KEY",
+                bool(os.getenv("AWS_SECRET_ACCESS_KEY")),
+            )
+        elif ctx.provider == "azure":
+            print_status("AZURE_ACCOUNT_NAME", bool(os.getenv("AZURE_ACCOUNT_NAME")))
+            print_status("AZURE_ACCOUNT_KEY", bool(os.getenv("AZURE_ACCOUNT_KEY")))
+        elif ctx.provider == "gcp":
+            print_status("GOOGLE_PROJECT_ID", bool(os.getenv("GOOGLE_PROJECT_ID")))
+            print_status(
+                "GOOGLE_APPLICATION_CREDENTIALS",
+                bool(os.getenv("GOOGLE_APPLICATION_CREDENTIALS")),
+            )
 
-    if not RESTIC_REPOSITORY or not RESTIC_PASSWORD:
-        log("[FATAL] Variáveis obrigatórias estão ausentes. Abortando.", log_file)
-        print("\n[FATAL] Variáveis obrigatórias estão ausentes. Abortando.")
-        sys.exit(1)
+        if not ctx.repository or not restic_password:
+            ctx.log("[FATAL] Variáveis obrigatórias estão ausentes. Abortando.")
+            print("\n[FATAL] Variáveis obrigatórias estão ausentes. Abortando.")
+            sys.exit(1)
 
-    # === 4. Verificar se Restic está no PATH ===
-    log("\nVerificando se 'restic' está disponível no PATH...", log_file)
-    success, _ = run_cmd(
-        ["restic", "version"],
-        log_file,
-        error_msg="Restic não encontrado ou com erro",
-    )
-    if not success:
-        sys.exit(1)
-    log("Restic está instalado e acessível.", log_file)
-    print("Restic está instalado e acessível.")
-
-    # === 5. Testar acesso ao repositório ===
-    log("\nTestando acesso ao repositório...", log_file)
-    success, _ = run_cmd(
-        ["restic", "-r", RESTIC_REPOSITORY, "snapshots"],
-        log_file,
-        env=env,
-        error_msg="Não foi possível acessar o repositório",
-    )
-    if success:
-        log("Acesso ao repositório bem-sucedido.", log_file)
-        print("Acesso ao repositório bem-sucedido.")
-    else:
-        print("Não foi possível acessar o repositório.")
-        log("Tentando inicializar...", log_file)
-
-        success, _ = run_cmd(
-            ["restic", "-r", RESTIC_REPOSITORY, "init"],
-            log_file,
-            env=env,
-            error_msg="Falha ao inicializar o repositório",
-            success_msg="Repositório foi inicializado com sucesso!",
+        ctx.log("\nVerificando se 'restic' está disponível no PATH...")
+        success, _ = ctx.run_cmd(
+            ["restic", "version"],
+            error_msg="Restic não encontrado ou com erro",
         )
         if not success:
             sys.exit(1)
+        ctx.log("Restic está instalado e acessível.")
+        print("Restic está instalado e acessível.")
+
+        ctx.log("\nTestando acesso ao repositório...")
+        success, _ = ctx.run_cmd(
+            ["restic", "-r", ctx.repository, "snapshots"],
+            error_msg="Não foi possível acessar o repositório",
+        )
+        if success:
+            ctx.log("Acesso ao repositório bem-sucedido.")
+            print("Acesso ao repositório bem-sucedido.")
+        else:
+            print("Não foi possível acessar o repositório.")
+            ctx.log("Tentando inicializar...")
+            success, _ = ctx.run_cmd(
+                ["restic", "-r", ctx.repository, "init"],
+                error_msg="Falha ao inicializar o repositório",
+                success_msg="Repositório foi inicializado com sucesso!",
+            )
+            if not success:
+                sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/list_snapshots.py
+++ b/list_snapshots.py
@@ -2,32 +2,19 @@
 
 from __future__ import annotations
 
-import os
 import sys
 
-from services.restic import load_restic_env
-from services.logger import create_log_file, log, run_cmd
+from services.script import ResticScript
 
 
 def list_snapshots() -> None:
     """Fetch and print all snapshots from the repository."""
 
-    try:
-        repository, env, _ = load_restic_env()
-    except ValueError as exc:  # pragma: no cover - configuration errors
-        print(f"[FATAL] {exc}")
-        sys.exit(1)
+    with ResticScript("list_snapshots") as ctx:
+        ctx.log(f"Listando snapshots do repositório: {ctx.repository}\n")
 
-    log_dir = os.getenv("LOG_DIR", "logs")
-    log_filename = create_log_file("list_snapshots", log_dir)
-
-    with open(log_filename, "w", encoding="utf-8") as log_file:
-        log(f"Listando snapshots do repositório: {repository}\n", log_file)
-
-        success, _ = run_cmd(
-            ["restic", "-r", repository, "snapshots"],
-            log_file,
-            env=env,
+        success, _ = ctx.run_cmd(
+            ["restic", "-r", ctx.repository, "snapshots"],
             error_msg="Falha ao listar snapshots",
         )
         if not success:

--- a/list_snapshots_with_size.py
+++ b/list_snapshots_with_size.py
@@ -3,30 +3,17 @@
 from __future__ import annotations
 
 import json
-import os
 import sys
 
-from services.restic import load_restic_env
-from services.logger import create_log_file, log, run_cmd
+from services.script import ResticScript
 
 
 def list_snapshots_with_size() -> None:
     """Print snapshot information including estimated restore size."""
 
-    try:
-        repository, env, _ = load_restic_env()
-    except ValueError as exc:  # pragma: no cover - configuration errors
-        print(f"[FATAL] {exc}")
-        sys.exit(1)
-
-    log_dir = os.getenv("LOG_DIR", "logs")
-    log_filename = create_log_file("list_snapshots_with_size", log_dir)
-
-    with open(log_filename, "w", encoding="utf-8") as log_file:
-        success, result = run_cmd(
-            ["restic", "-r", repository, "snapshots", "--json"],
-            log_file,
-            env=env,
+    with ResticScript("list_snapshots_with_size") as ctx:
+        success, result = ctx.run_cmd(
+            ["restic", "-r", ctx.repository, "snapshots", "--json"],
             error_msg="Falha ao buscar snapshots",
         )
         if not success or result is None:
@@ -34,10 +21,10 @@ def list_snapshots_with_size() -> None:
         try:
             snapshots = json.loads(result.stdout)
         except json.JSONDecodeError as exc:
-            log(f"Erro ao decodificar JSON: {exc}", log_file)
+            ctx.log(f"Erro ao decodificar JSON: {exc}")
             sys.exit(1)
 
-        log(f"Listando snapshots do repositório: {repository}\n", log_file)
+        ctx.log(f"Listando snapshots do repositório: {ctx.repository}\n")
 
         for snap in snapshots:
             short_id = snap["short_id"]
@@ -45,19 +32,17 @@ def list_snapshots_with_size() -> None:
             hostname = snap["hostname"]
             paths = ", ".join(snap["paths"])
 
-            success, stats_res = run_cmd(
+            success, stats_res = ctx.run_cmd(
                 [
                     "restic",
                     "-r",
-                    repository,
+                    ctx.repository,
                     "stats",
                     short_id,
                     "--mode",
                     "restore-size",
                     "--json",
                 ],
-                log_file,
-                env=env,
                 error_msg="Erro ao calcular tamanho",
             )
 
@@ -67,18 +52,17 @@ def list_snapshots_with_size() -> None:
                     total_bytes = stats.get("total_size", 0)
                     total_gib = total_bytes / (1024 ** 3)
                     print(
-                        f"{short_id} | {time} | {hostname} | {paths} | {total_gib:.3f} GiB"
+                        f"{short_id} | {time} | {hostname} | {paths} | {total_gib:.3f} GiB",
                     )
                 except json.JSONDecodeError:
                     print(
-                        f"{short_id} | {time} | {hostname} | {paths} | (erro ao calcular tamanho)"
+                        f"{short_id} | {time} | {hostname} | {paths} | (erro ao calcular tamanho)",
                     )
             else:
                 print(
-                    f"{short_id} | {time} | {hostname} | {paths} | (erro ao calcular tamanho)"
+                    f"{short_id} | {time} | {hostname} | {paths} | (erro ao calcular tamanho)",
                 )
 
 
 if __name__ == "__main__":
     list_snapshots_with_size()
-

--- a/manual_prune.py
+++ b/manual_prune.py
@@ -1,50 +1,36 @@
 import os
 import sys
 
-from services.restic import load_restic_env
-from services.logger import create_log_file, log, run_cmd
-
-# === 1. Carregar configurações do Restic ===
-try:
-    RESTIC_REPOSITORY, env, _ = load_restic_env()
-except ValueError as e:
-    print(f"[FATAL] {e}")
-    sys.exit(1)
-
-LOG_DIR = os.getenv("LOG_DIR", "logs")
-log_filename = create_log_file("manual_prune", LOG_DIR)
-
-# === 2. Coletar políticas de retenção do .env ou usar defaults ===
-RETENTION_KEEP_DAILY = os.getenv("RETENTION_KEEP_DAILY", "7")
-RETENTION_KEEP_WEEKLY = os.getenv("RETENTION_KEEP_WEEKLY", "4")
-RETENTION_KEEP_MONTHLY = os.getenv("RETENTION_KEEP_MONTHLY", "6")
+from services.script import ResticScript
 
 
 def main() -> None:
-    with open(log_filename, "w", encoding="utf-8") as log_file:
-        log("Aplicando política de retenção manual:", log_file)
-        log(f"  Diário:   {RETENTION_KEEP_DAILY}", log_file)
-        log(f"  Semanal:  {RETENTION_KEEP_WEEKLY}", log_file)
-        log(f"  Mensal:   {RETENTION_KEEP_MONTHLY}", log_file)
+    with ResticScript("manual_prune") as ctx:
+        keep_daily = os.getenv("RETENTION_KEEP_DAILY", "7")
+        keep_weekly = os.getenv("RETENTION_KEEP_WEEKLY", "4")
+        keep_monthly = os.getenv("RETENTION_KEEP_MONTHLY", "6")
+
+        ctx.log("Aplicando política de retenção manual:")
+        ctx.log(f"  Diário:   {keep_daily}")
+        ctx.log(f"  Semanal:  {keep_weekly}")
+        ctx.log(f"  Mensal:   {keep_monthly}")
 
         cmd = [
             "restic",
             "-r",
-            RESTIC_REPOSITORY,
+            ctx.repository,
             "forget",
             "--keep-daily",
-            RETENTION_KEEP_DAILY,
+            keep_daily,
             "--keep-weekly",
-            RETENTION_KEEP_WEEKLY,
+            keep_weekly,
             "--keep-monthly",
-            RETENTION_KEEP_MONTHLY,
+            keep_monthly,
             "--prune",
         ]
 
-        success, _ = run_cmd(
+        success, _ = ctx.run_cmd(
             cmd,
-            log_file,
-            env=env,
             success_msg="Política de retenção aplicada com sucesso.",
             error_msg="Erro ao aplicar política de retenção.",
         )

--- a/repository_stats.py
+++ b/repository_stats.py
@@ -3,40 +3,27 @@
 from __future__ import annotations
 
 import json
-import os
 import sys
 
-from services.restic import load_restic_env
-from services.logger import create_log_file, log, run_cmd
+from services.script import ResticScript
 
 
 def show_repository_stats() -> None:
     """Print repository size information."""
 
-    try:
-        repository, env, _ = load_restic_env()
-    except ValueError as exc:  # pragma: no cover - configuration errors
-        print(f"[FATAL] {exc}")
-        sys.exit(1)
+    with ResticScript("repository_stats") as ctx:
+        ctx.log(f"Obtendo estatísticas gerais do repositório: {ctx.repository}\n")
 
-    log_dir = os.getenv("LOG_DIR", "logs")
-    log_filename = create_log_file("repository_stats", log_dir)
-
-    with open(log_filename, "w", encoding="utf-8") as log_file:
-        log(f"Obtendo estatísticas gerais do repositório: {repository}\n", log_file)
-
-        success, result = run_cmd(
+        success, result = ctx.run_cmd(
             [
                 "restic",
                 "-r",
-                repository,
+                ctx.repository,
                 "stats",
                 "--mode",
                 "raw-data",
                 "--json",
             ],
-            log_file,
-            env=env,
             error_msg="Falha ao obter estatísticas",
         )
         if not success or result is None:
@@ -45,7 +32,7 @@ def show_repository_stats() -> None:
         try:
             stats = json.loads(result.stdout)
         except json.JSONDecodeError as exc:
-            log(f"Erro ao decodificar JSON: {exc}", log_file)
+            ctx.log(f"Erro ao decodificar JSON: {exc}")
             sys.exit(1)
 
         size_bytes = stats.get("total_size", 0)

--- a/restic_backup.py
+++ b/restic_backup.py
@@ -1,117 +1,83 @@
 import os
 import sys
 
-from services.restic import load_restic_env
-from services.logger import create_log_file, log, run_cmd
+from services.script import ResticScript
 
-# === Carregar configurações do Restic ===
-try:
-    RESTIC_REPOSITORY, env, _ = load_restic_env()
-except ValueError as e:
-    print(f"[FATAL] {e}")
-    sys.exit(1)
 
-# Diretório onde os logs serão salvos
-LOG_DIR = os.getenv("LOG_DIR", "logs")
-
-# === Configurações de backup ===
-SOURCE_DIRS = os.getenv("BACKUP_SOURCE_DIRS", "").split(",")  # múltiplos diretórios
-EXCLUDES = os.getenv("RESTIC_EXCLUDES", "").split(",")        # padrões de exclusão
-TAGS = os.getenv("RESTIC_TAGS", "").split(",")                # tags aplicadas ao snapshot
-
-# === Política de retenção configurável ===
-RETENTION_ENABLED = os.getenv("RETENTION_ENABLED", "true").lower() == "true"
-RETENTION_KEEP_HOURLY  = os.getenv("RETENTION_KEEP_HOURLY", "0")
-RETENTION_KEEP_DAILY = os.getenv("RETENTION_KEEP_DAILY", "7")
-RETENTION_KEEP_WEEKLY = os.getenv("RETENTION_KEEP_WEEKLY", "4")
-RETENTION_KEEP_MONTHLY = os.getenv("RETENTION_KEEP_MONTHLY", "6")
-
-# === Verificações mínimas obrigatórias ===
-if not any(SOURCE_DIRS):
-    print("[FATAL] Variáveis obrigatórias ausentes no .env")
-    sys.exit(1)
-
-# === Cria arquivo de log com timestamp ===
-log_filename = create_log_file("backup", LOG_DIR)
-
-# === Monta argumentos repetidos como --tag ou --exclude ===
 def build_args(prefix, items):
-    """Repete ``prefix`` para cada item não vazio.
-
-    Parameters
-    ----------
-    prefix: str
-        Flag a ser repetida, por exemplo ``"--tag"``.
-    items: list[str]
-        Itens que serão associados ao prefixo.
-    """
+    """Repete ``prefix`` para cada item não vazio."""
     return [arg for i in items for arg in (prefix, i.strip()) if i.strip()]
 
-# === Função principal que executa backup e retenção ===
-def run_backup():
-    with open(log_filename, "w", encoding="utf-8") as log_file:
-        log("=== Iniciando backup com Restic ===", log_file)
 
-        # === Verifica se o repositório é acessível ===
-        log("🔍 Verificando acesso ao repositório...", log_file)
-        if not run_cmd(
-            ["restic", "-r", RESTIC_REPOSITORY, "snapshots"],
-            log_file,
-            env=env,
+def run_backup():
+    with ResticScript("backup") as ctx:
+        source_dirs = os.getenv("BACKUP_SOURCE_DIRS", "").split(",")
+        excludes = os.getenv("RESTIC_EXCLUDES", "").split(",")
+        tags = os.getenv("RESTIC_TAGS", "").split(",")
+
+        retention_enabled = os.getenv("RETENTION_ENABLED", "true").lower() == "true"
+        keep_hourly = os.getenv("RETENTION_KEEP_HOURLY", "0")
+        keep_daily = os.getenv("RETENTION_KEEP_DAILY", "7")
+        keep_weekly = os.getenv("RETENTION_KEEP_WEEKLY", "4")
+        keep_monthly = os.getenv("RETENTION_KEEP_MONTHLY", "6")
+
+        if not any(source_dirs):
+            print("[FATAL] Variáveis obrigatórias ausentes no .env")
+            sys.exit(1)
+
+        ctx.log("=== Iniciando backup com Restic ===")
+
+        ctx.log("🔍 Verificando acesso ao repositório...")
+        if not ctx.run_cmd(
+            ["restic", "-r", ctx.repository, "snapshots"],
             success_msg="✅ Repositório acessível.",
             error_msg="Não foi possível acessar o repositório. Abortando.",
         )[0]:
             return
 
-        # === Executa o backup propriamente dito ===
-        cmd_backup = ["restic", "-r", RESTIC_REPOSITORY, "backup"]
-        cmd_backup += [d.strip() for d in SOURCE_DIRS if d.strip()]
-        cmd_backup += build_args("--exclude", EXCLUDES)
-        cmd_backup += build_args("--tag", TAGS)
+        cmd_backup = ["restic", "-r", ctx.repository, "backup"]
+        cmd_backup += [d.strip() for d in source_dirs if d.strip()]
+        cmd_backup += build_args("--exclude", excludes)
+        cmd_backup += build_args("--tag", tags)
 
-        log(f"Executando backup de: {', '.join(SOURCE_DIRS)}", log_file)
-        run_cmd(
+        ctx.log(f"Executando backup de: {', '.join(source_dirs)}")
+        ctx.run_cmd(
             cmd_backup,
-            log_file,
-            env=env,
             success_msg="Backup concluído.",
             error_msg="Erro durante o backup.",
         )
 
-        # === Se ativado, aplica política de retenção ===
-        if RETENTION_ENABLED:
-            log("Aplicando política de retenção...", log_file)
+        if retention_enabled:
+            ctx.log("Aplicando política de retenção...")
             cmd_retention = [
                 "restic",
                 "-r",
-                RESTIC_REPOSITORY,
+                ctx.repository,
                 "forget",
                 "--keep-hourly",
-                RETENTION_KEEP_HOURLY,
+                keep_hourly,
                 "--keep-daily",
-                RETENTION_KEEP_DAILY,
+                keep_daily,
                 "--keep-weekly",
-                RETENTION_KEEP_WEEKLY,
+                keep_weekly,
                 "--keep-monthly",
-                RETENTION_KEEP_MONTHLY,
+                keep_monthly,
                 "--prune",
             ]
-            run_cmd(
+            ctx.run_cmd(
                 cmd_retention,
-                log_file,
-                env=env,
                 success_msg="Política de retenção aplicada.",
                 error_msg="Erro ao aplicar retenção.",
             )
         else:
-            log("Retenção desativada via .env.", log_file)
+            ctx.log("Retenção desativada via .env.")
 
-        log("=== Fim do backup ===", log_file)
+        ctx.log("=== Fim do backup ===")
 
-# === Execução principal ===
+
 if __name__ == "__main__":
     try:
         run_backup()
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - runtime errors
         print(f"[FATAL] Erro inesperado: {e}")
         sys.exit(1)

--- a/services/script.py
+++ b/services/script.py
@@ -1,0 +1,86 @@
+"""Shared context manager for CLI scripts.
+
+This module exposes :class:`ResticScript` which centralises the boilerplate
+needed by all command line utilities: loading the Restic environment
+configuration, preparing a timestamped log file and providing helper methods
+for logging and running external commands.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Sequence, TextIO
+
+from .restic import load_restic_env
+from .logger import create_log_file, log as _log, run_cmd as _run_cmd
+
+
+class ResticScript:
+    """Context manager used by CLI scripts.
+
+    Parameters
+    ----------
+    log_prefix: str
+        Identifier used for the generated log file name.
+    log_dir: str | None
+        Directory where log files will be stored. Defaults to the ``LOG_DIR``
+        environment variable or ``"logs"`` when unset.
+    """
+
+    def __init__(self, log_prefix: str, log_dir: str | None = None):
+        self.log_prefix = log_prefix
+        self.log_dir = log_dir or os.getenv("LOG_DIR", "logs")
+        self.repository: str = ""
+        self.env: dict[str, str] = {}
+        self.provider: str = ""
+        self.log_filename: str = ""
+        self.log_file: TextIO | None = None
+
+    def __enter__(self) -> "ResticScript":
+        try:
+            self.repository, self.env, self.provider = load_restic_env()
+        except ValueError as exc:  # pragma: no cover - environment errors
+            print(f"[FATAL] {exc}")
+            raise SystemExit(1)
+
+        try:
+            self.log_filename = create_log_file(self.log_prefix, self.log_dir)
+            self.log_file = open(self.log_filename, "w", encoding="utf-8")
+        except Exception as exc:  # pragma: no cover - filesystem errors
+            print(f"[FATAL] Falha ao preparar log: {exc}")
+            raise SystemExit(1)
+
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self.log_file is not None:
+            self.log_file.close()
+
+    # Convenience wrappers -------------------------------------------------
+    def log(self, message: str) -> None:
+        """Write ``message`` to the log file and stdout."""
+        if self.log_file is None:  # pragma: no cover - defensive programming
+            raise RuntimeError("ResticScript not initialised")
+        _log(message, self.log_file)
+
+    def run_cmd(
+        self,
+        cmd: Sequence[str],
+        *,
+        success_msg: str | None = None,
+        error_msg: str | None = None,
+    ):
+        """Execute ``cmd`` forwarding output to the log file.
+
+        Returns the tuple ``(success, CompletedProcess)`` from
+        :func:`services.logger.run_cmd`.
+        """
+        if self.log_file is None:  # pragma: no cover - defensive programming
+            raise RuntimeError("ResticScript not initialised")
+        return _run_cmd(
+            cmd,
+            self.log_file,
+            env=self.env,
+            success_msg=success_msg,
+            error_msg=error_msg,
+        )


### PR DESCRIPTION
## Summary
- centralize environment loading and logging with `ResticScript`
- switch snapshot utilities to `argparse` for robust CLI arguments
- update Makefile to pass new `--id` and `--path` options

