### PR TITLE
refactor: centralize credential source loading in CLI utilities

### DIFF
--- a/check_restic_access.py
+++ b/check_restic_access.py
@@ -1,9 +1,8 @@
 import logging
-import os
 import sys
 
 from services.script import ResticScript
-from services.restic_client import ResticClient, ResticError
+from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
 
 
 def check_restic_access() -> None:
@@ -11,8 +10,8 @@ def check_restic_access() -> None:
     
     Utiliza o ResticClient para verificar acesso ao repositorio com retry automatico e tratamento de erros.
     """
-    # Usar ResticScript que já carrega as credenciais corretamente
-    with ResticScript("check_restic_access") as ctx:
+    credential_source = load_env_and_get_credential_source()
+    with ResticScript("check_restic_access", credential_source=credential_source) as ctx:
         # Configurar logging
         logging.basicConfig(
             level=logging.INFO,
@@ -61,7 +60,7 @@ def check_restic_access() -> None:
                 repository=ctx.repository,
                 env=ctx.env,
                 provider=ctx.provider,
-                credential_source=ctx.credential_source
+                credential_source=credential_source
             )
             
             # Verificar se o Restic esta disponivel

--- a/examples/timestamped_restore.py
+++ b/examples/timestamped_restore.py
@@ -10,12 +10,11 @@ import os
 import sys
 from pathlib import Path
 from datetime import datetime
-from dotenv import load_dotenv
 
 # Adicionar o diretório pai ao path para importar os módulos
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from services.restic_client import ResticClient, ResticError
+from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
 from services.restore_utils import (
     create_timestamped_restore_path,
     create_full_restore_structure,
@@ -32,10 +31,8 @@ def demonstrate_timestamped_restore():
     print("=" * 70)
     
     try:
-        # Carregar configurações do ambiente
-        load_dotenv()
-        credential_source = os.getenv('CREDENTIAL_SOURCE', 'env')
-        
+        credential_source = load_env_and_get_credential_source()
+
         # Criar cliente Restic
         client = ResticClient(credential_source=credential_source)
         

--- a/list_snapshot_files.py
+++ b/list_snapshot_files.py
@@ -1,13 +1,11 @@
 import argparse
 import json
 import logging
-import os
 import sys
 from pathlib import Path
-from dotenv import load_dotenv
 
 from services.script import ResticScript
-from services.restic_client import ResticClient, ResticError
+from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
 
 
 def parse_args() -> argparse.Namespace:
@@ -22,8 +20,8 @@ def parse_args() -> argparse.Namespace:
 
 
 def main(snapshot_id: str, output_format: str = "text", output_file: str = None, pretty: bool = False) -> None:
-    # Usar ResticScript que já carrega as credenciais corretamente
-    with ResticScript("list_snapshot_files") as ctx:
+    credential_source = load_env_and_get_credential_source()
+    with ResticScript("list_snapshot_files", credential_source=credential_source) as ctx:
         # Configurar logging
         logging.basicConfig(
             level=logging.INFO,

--- a/list_snapshots_with_size.py
+++ b/list_snapshots_with_size.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import json
-import os
 import sys
 import logging
-from dotenv import load_dotenv
 
 from services.script import ResticScript
-from services.restic_client import ResticClient, ResticError
+from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
 
 
 def list_snapshots_with_size() -> None:
@@ -17,8 +15,8 @@ def list_snapshots_with_size() -> None:
     
     Utiliza o ResticClient para obter snapshots e seus tamanhos com retry automatico e tratamento de erros.
     """
-    # Usar ResticScript que já carrega as credenciais corretamente
-    with ResticScript("list_snapshots_with_size") as ctx:
+    credential_source = load_env_and_get_credential_source()
+    with ResticScript("list_snapshots_with_size", credential_source=credential_source) as ctx:
         # Configurar logging
         logging.basicConfig(
             level=logging.INFO,

--- a/manual_prune.py
+++ b/manual_prune.py
@@ -1,10 +1,9 @@
 import logging
 import os
 import sys
-from dotenv import load_dotenv
 
 from services.script import ResticScript
-from services.restic_client import ResticClient, ResticError
+from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
 
 
 def main() -> None:
@@ -12,8 +11,8 @@ def main() -> None:
     
     Utiliza o ResticClient para aplicar politicas de retencao com retry automatico e tratamento de erros.
     """
-    # Usar ResticScript que já carrega as credenciais corretamente
-    with ResticScript("manual_prune") as ctx:
+    credential_source = load_env_and_get_credential_source()
+    with ResticScript("manual_prune", credential_source=credential_source) as ctx:
         # Configurar logging
         logging.basicConfig(
             level=logging.INFO,

--- a/repository_stats.py
+++ b/repository_stats.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import logging
-import os
 import sys
-from dotenv import load_dotenv
 
 from services.script import ResticScript
-from services.restic_client import ResticClient, ResticError
+from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
 
 
 def show_repository_stats() -> None:
@@ -16,8 +14,8 @@ def show_repository_stats() -> None:
     
     Utiliza o ResticClient para obter estatisticas com retry automatico e tratamento de erros.
     """
-    # Usar ResticScript que já carrega as credenciais corretamente
-    with ResticScript("repository_stats") as ctx:
+    credential_source = load_env_and_get_credential_source()
+    with ResticScript("repository_stats", credential_source=credential_source) as ctx:
         # Configurar logging
         logging.basicConfig(
             level=logging.INFO,

--- a/restore_file.py
+++ b/restore_file.py
@@ -4,10 +4,9 @@ import logging
 import os
 from datetime import datetime
 from pathlib import Path
-from dotenv import load_dotenv
 
 from services.script import ResticScript
-from services.restic_client import ResticClient, ResticError
+from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
 from services.restore_utils import (
     create_full_restore_structure,
     format_restore_info,
@@ -40,8 +39,8 @@ def run_restore_file(snapshot_id: str, include_path: str) -> None:
     include_path : str
         Caminho do arquivo ou diretorio a ser restaurado
     """
-    # Usar ResticScript que já carrega as credenciais corretamente
-    with ResticScript("restore_file") as ctx:
+    credential_source = load_env_and_get_credential_source()
+    with ResticScript("restore_file", credential_source=credential_source) as ctx:
         # Configurar logging
         logging.basicConfig(
             level=logging.INFO,

--- a/scripts/check_credentials.py
+++ b/scripts/check_credentials.py
@@ -20,11 +20,9 @@ try:
 except ImportError:
     get_credential = None
 
-try:
-    from dotenv import load_dotenv
-    load_dotenv()
-except ImportError:
-    pass
+from services.restic_client import load_env_and_get_credential_source
+
+credential_source = load_env_and_get_credential_source().lower()
 
 
 def check_restic_password() -> Tuple[bool, str]:
@@ -33,9 +31,6 @@ def check_restic_password() -> Tuple[bool, str]:
     Returns:
         Tuple[bool, str]: (configurado, mensagem)
     """
-    # Obter CREDENTIAL_SOURCE do .env
-    credential_source = os.getenv('CREDENTIAL_SOURCE', 'env').lower()
-    
     # Tentar obter da fonte configurada
     if get_credential:
         try:
@@ -67,7 +62,6 @@ def check_cloud_credentials() -> Tuple[bool, List[str]]:
         Tuple[bool, List[str]]: (todas_configuradas, lista_de_mensagens)
     """
     provider = os.getenv('STORAGE_PROVIDER', '').lower()
-    credential_source = os.getenv('CREDENTIAL_SOURCE', 'env').lower()
     messages = []
     all_configured = True
     

--- a/scripts/diagnose_azure_linux.py
+++ b/scripts/diagnose_azure_linux.py
@@ -11,7 +11,8 @@ import sys
 import subprocess
 import json
 from pathlib import Path
-from dotenv import load_dotenv
+
+from services.restic_client import load_env_and_get_credential_source
 
 # Importar load_restic_env para carregar configurações como no Windows
 try:
@@ -103,9 +104,7 @@ def check_azure_credentials():
     
     if HAS_RESTIC_SERVICE:
         try:
-            # Carregar .env primeiro para obter CREDENTIAL_SOURCE
-            load_dotenv()
-            credential_source = os.getenv("CREDENTIAL_SOURCE", "env")
+            credential_source = load_env_and_get_credential_source()
             
             print(f"🔧 Usando load_restic_env com credential_source='{credential_source}' (como no Windows)")
             repository, env_vars, provider = load_restic_env(credential_source)
@@ -117,7 +116,7 @@ def check_azure_credentials():
     
     if not HAS_RESTIC_SERVICE or not repository:
         # Fallback para carregamento manual
-        load_dotenv()
+        load_env_and_get_credential_source()
         env_vars = dict(os.environ)
         repository = os.getenv("RESTIC_REPOSITORY")
         provider = os.getenv("STORAGE_PROVIDER")
@@ -168,15 +167,14 @@ def test_azure_connectivity():
     
     if HAS_RESTIC_SERVICE:
         try:
-            load_dotenv()
-            credential_source = os.getenv("CREDENTIAL_SOURCE", "env")
+            credential_source = load_env_and_get_credential_source()
             repository, env_vars, provider = load_restic_env(credential_source)
         except Exception:
-            load_dotenv()
+            load_env_and_get_credential_source()
             env_vars = dict(os.environ)
             repository = os.getenv("RESTIC_REPOSITORY")
     else:
-        load_dotenv()
+        load_env_and_get_credential_source()
         env_vars = dict(os.environ)
         repository = os.getenv("RESTIC_REPOSITORY")
     

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from services.logger import setup_logger
 from services.restic import load_restic_config, load_restic_env
-from services.restic_client import ResticClient
+from services.restic_client import ResticClient, load_env_and_get_credential_source
 
 logger = setup_logger(__name__)
 
@@ -122,8 +122,7 @@ class HealthChecker:
     def check_restic_config(self):
         """Verifica configuracao do Restic"""
         try:
-            # Obter CREDENTIAL_SOURCE do .env
-            credential_source = os.getenv('CREDENTIAL_SOURCE', 'env')
+            credential_source = load_env_and_get_credential_source()
             config = load_restic_config(credential_source)
             
             # Verificar variaveis essenciais
@@ -156,8 +155,7 @@ class HealthChecker:
     def check_restic_repository(self):
         """Verifica acesso ao repositorio Restic"""
         try:
-            # Carregar ambiente com credential_source correto
-            credential_source = os.getenv("CREDENTIAL_SOURCE", "env")
+            credential_source = load_env_and_get_credential_source()
             repository, env, provider = load_restic_env(credential_source)
             
             client = ResticClient(

--- a/scripts/validate_setup.py
+++ b/scripts/validate_setup.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from services.logger import setup_logger
 from services.restic import load_restic_config, load_restic_env
-from services.restic_client import ResticClient
+from services.restic_client import ResticClient, load_env_and_get_credential_source
 
 logger = setup_logger(__name__)
 
@@ -175,8 +175,7 @@ class SetupValidator:
         print("\n Validando configuracao Restic...")
         
         try:
-            # Obter CREDENTIAL_SOURCE do .env
-            credential_source = os.getenv('CREDENTIAL_SOURCE', 'env')
+            credential_source = load_env_and_get_credential_source()
             config = load_restic_config(credential_source)
             
             # Verificar configuracoes criticas
@@ -236,8 +235,7 @@ class SetupValidator:
         print("\n Validando acesso ao repositorio...")
         
         try:
-            # Carregar ambiente com credential_source correto
-            credential_source = os.getenv("CREDENTIAL_SOURCE", "env")
+            credential_source = load_env_and_get_credential_source()
             repository, env, provider = load_restic_env(credential_source)
             
             client = ResticClient(


### PR DESCRIPTION
## Summary
- centralize credential source retrieval with `load_env_and_get_credential_source`
- remove redundant `load_dotenv` and environment reads across CLI scripts
- update helper scripts and diagnostics to use shared credential loading

