### PR TITLE
Use ResticConfig in CLI scripts

### DIFF
--- a/list_snapshot_files.py
+++ b/list_snapshot_files.py
@@ -1,10 +1,8 @@
 import argparse
 import json
 import logging
-import os
 import sys
 from pathlib import Path
-from dotenv import load_dotenv
 
 from services.script import ResticScript
 from services.restic_client import ResticClient, ResticError
@@ -34,8 +32,13 @@ def main(snapshot_id: str, output_format: str = "text", output_file: str = None,
         ctx.log(f"Listando arquivos do snapshot '{snapshot_id}'...")
         
         try:
-            # Criar cliente Restic com retry
-            client = ResticClient(max_attempts=3, credential_source=credential_source)
+            client = ResticClient(
+                max_attempts=3,
+                repository=ctx.repository,
+                env=ctx.env,
+                provider=ctx.provider,
+                credential_source=ctx.credential_source,
+            )
             
             # Listar arquivos do snapshot
             files_output = client.list_snapshot_files(snapshot_id)

--- a/list_snapshot_files.py
+++ b/list_snapshot_files.py
@@ -1,7 +1,6 @@
 import argparse
 import json
 import logging
-import sys
 from pathlib import Path
 
 from services.script import ResticScript
@@ -81,10 +80,10 @@ def main(snapshot_id: str, output_format: str = "text", output_file: str = None,
                 
         except ResticError as exc:
             ctx.log(f"[ERRO] {exc}")
-            sys.exit(1)
+            raise SystemExit(1)
         except Exception as exc:
             ctx.log(f"[ERRO] Uma falha inesperada ocorreu: {exc}")
-            sys.exit(1)
+            raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/list_snapshots.py
+++ b/list_snapshots.py
@@ -2,22 +2,16 @@
 
 from __future__ import annotations
 
-import os
 import sys
 from datetime import datetime
 import logging
 from services.script import ResticScript
-from services.restic_client import ResticClient, load_env_and_get_credential_source, ResticError
+from services.restic_client import ResticClient, ResticError
 
 
 def list_snapshots() -> None:
-    """Fetch and print all snapshots from the repository.
-    
-    Utiliza o ResticClient para obter a lista de snapshots com retry automatico e tratamento de erros.
-    """
-    credential_source = load_env_and_get_credential_source()
-
-    with ResticScript("list_snapshots", credential_source=credential_source) as ctx:
+    """Fetch and print all snapshots from the repository."""
+    with ResticScript("list_snapshots") as ctx:
         # Configurar logging
         logging.basicConfig(
             level=logging.INFO,
@@ -34,7 +28,7 @@ def list_snapshots() -> None:
                 repository=ctx.repository,
                 env=ctx.env,
                 provider=ctx.provider,
-                credential_source=credential_source
+                credential_source=ctx.credential_source,
             )
             
             # Obter lista de snapshots

--- a/list_snapshots.py
+++ b/list_snapshots.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 from datetime import datetime
 import logging
 from services.script import ResticScript
@@ -36,7 +35,7 @@ def list_snapshots() -> None:
             
             if not snapshots:
                 ctx.log("Nenhum snapshot encontrado no repositorio.")
-                sys.exit(0)
+                raise SystemExit(0)
 
             print("{:<12} {:<20} {:<15} {}".format("ID", "Data", "Host", "Caminhos"))
             print("-" * 80)
@@ -58,10 +57,10 @@ def list_snapshots() -> None:
 
         except ResticError as exc:
             ctx.log(f"[ERRO] {exc}")
-            sys.exit(1)
+            raise SystemExit(1)
         except Exception as exc:
             ctx.log(f"[ERRO] Uma falha inesperada ocorreu: {exc}")
-            sys.exit(1)
+            raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/list_snapshots_with_size.py
+++ b/list_snapshots_with_size.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
-import json
-import os
 import sys
 import logging
-from dotenv import load_dotenv
 
 from services.script import ResticScript
 from services.restic_client import ResticClient, ResticError
@@ -27,12 +24,11 @@ def list_snapshots_with_size() -> None:
         )
         
         try:
-            # Criar cliente Restic com retry usando o ambiente já carregado
             client = ResticClient(
                 repository=ctx.repository,
                 env=ctx.env,
                 provider=ctx.provider,
-                credential_source=credential_source
+                credential_source=ctx.credential_source,
             )
             
             # Obter lista de snapshots

--- a/list_snapshots_with_size.py
+++ b/list_snapshots_with_size.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 import logging
 
 from services.script import ResticScript
@@ -62,10 +61,10 @@ def list_snapshots_with_size() -> None:
 
         except ResticError as exc:
             ctx.log(f"[ERRO] {exc}")
-            sys.exit(1)
+            raise SystemExit(1)
         except Exception as exc:
             ctx.log(f"[ERRO] Uma falha inesperada ocorreu: {exc}")
-            sys.exit(1)
+            raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/manual_prune.py
+++ b/manual_prune.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 from services.script import ResticScript
 from services.restic_client import ResticClient, ResticError
@@ -17,7 +16,7 @@ def main() -> None:
         config = ctx.config
         if not config:
             ctx.log("[FATAL] Configuracao do Restic nao carregada")
-            sys.exit(1)
+            raise SystemExit(1)
 
         ctx.log("=== Iniciando limpeza manual de snapshots com Restic ===")
 
@@ -45,14 +44,14 @@ def main() -> None:
                 ctx.log("✅ Limpeza de snapshots concluida com sucesso.")
             else:
                 ctx.log("Erro durante a limpeza de snapshots")
-                sys.exit(1)
+                raise SystemExit(1)
 
         except ResticError as exc:
             ctx.log(f"[ERRO] {exc}")
-            sys.exit(1)
+            raise SystemExit(1)
         except Exception as exc:
             ctx.log(f"[ERRO] Uma falha inesperada ocorreu: {exc}")
-            sys.exit(1)
+            raise SystemExit(1)
         finally:
             ctx.log("=== Fim do processo de limpeza de snapshots ===")
 

--- a/repository_stats.py
+++ b/repository_stats.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 
 from services.script import ResticScript
 from services.restic_client import ResticClient, ResticError
@@ -46,14 +45,14 @@ def show_repository_stats() -> None:
                 )
             else:
                 ctx.log("Nao foi possivel obter estatisticas do repositorio.")
-                sys.exit(1)
+                raise SystemExit(1)
                 
         except ResticError as exc:
             ctx.log(f"[ERRO] {exc}")
-            sys.exit(1)
+            raise SystemExit(1)
         except Exception as exc:
             ctx.log(f"[ERRO] Uma falha inesperada ocorreu: {exc}")
-            sys.exit(1)
+            raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/repository_stats.py
+++ b/repository_stats.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import logging
-import os
 import sys
-from dotenv import load_dotenv
 
 from services.script import ResticScript
 from services.restic_client import ResticClient, ResticError
@@ -34,7 +32,7 @@ def show_repository_stats() -> None:
                 repository=ctx.repository,
                 env=ctx.env,
                 provider=ctx.provider,
-                credential_source=credential_source
+                credential_source=ctx.credential_source,
             )
             
             # Obter estatisticas do repositorio

--- a/restic_backup.py
+++ b/restic_backup.py
@@ -1,99 +1,68 @@
-import os
-import sys
 import logging
-from typing import List
+import sys
 
 from services.script import ResticScript
-from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
+from services.restic_client import ResticClient, ResticError
 
 
-def build_args(prefix, items):
-    """Repete ``prefix`` para cada item nao vazio."""
-    return [arg for i in items for arg in (prefix, i.strip()) if i.strip()]
-
-
-def run_backup():
-    """Executa o backup com base nas variaveis do .env e aplica politica de retencao se ativada.
-    
-    Utiliza o ResticClient para executar o backup com retry automatico e tratamento de erros.
-    """
-    credential_source = load_env_and_get_credential_source()
-    
-    with ResticScript("backup", credential_source=credential_source) as ctx:
-        # Configurar logging
+def run_backup() -> None:
+    """Executa o backup baseado na configuracao carregada pelo ``ResticScript``."""
+    with ResticScript("backup") as ctx:
         logging.basicConfig(
             level=logging.INFO,
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
             handlers=[logging.StreamHandler()],
         )
-        
-        # Carregar variaveis de ambiente
-        source_dirs = os.getenv("BACKUP_SOURCE_DIRS", "").split(",")
-        source_dirs = [d.strip() for d in source_dirs if d.strip()]
-        excludes = os.getenv("RESTIC_EXCLUDES", "").split(",")
-        excludes = [e.strip() for e in excludes if e.strip()]
-        tags = os.getenv("RESTIC_TAGS", "").split(",")
-        tags = [t.strip() for t in tags if t.strip()]
 
-        retention_enabled = os.getenv("RETENTION_ENABLED", "true").lower() == "true"
-        keep_hourly = int(os.getenv("RETENTION_KEEP_HOURLY", "0"))
-        keep_daily = int(os.getenv("RETENTION_KEEP_DAILY", "7"))
-        keep_weekly = int(os.getenv("RETENTION_KEEP_WEEKLY", "4"))
-        keep_monthly = int(os.getenv("RETENTION_KEEP_MONTHLY", "6"))
-
-        if not source_dirs:
-            ctx.log("[FATAL] Variaveis obrigatorias ausentes no .env")
+        config = ctx.config
+        if not config or not config.backup_source_dirs:
+            ctx.log("[FATAL] Variaveis obrigatorias ausentes na configuracao")
             sys.exit(1)
 
         ctx.log("=== Iniciando backup com Restic ===")
 
-        # Criar cliente Restic com retry usando o ambiente já carregado
         client = ResticClient(
             max_attempts=3,
             repository=ctx.repository,
             env=ctx.env,
             provider=ctx.provider,
-            credential_source=credential_source
+            credential_source=ctx.credential_source,
         )
-        
+
         try:
-            # Verificar acesso ao repositorio
             ctx.log("🔍 Verificando acesso ao repositorio...")
             if not client.check_repository_access():
                 ctx.log("Nao foi possivel acessar o repositorio. Abortando.")
                 return
             ctx.log("✅ Repositorio acessivel.")
-            
-            # Executar backup
-            ctx.log(f"Executando backup de: {', '.join(source_dirs)}")
+
+            ctx.log(f"Executando backup de: {', '.join(config.backup_source_dirs)}")
             snapshot_id = client.backup(
-                paths=source_dirs,
-                excludes=excludes,
-                tags=tags,
+                paths=config.backup_source_dirs,
+                excludes=config.restic_excludes,
+                tags=config.restic_tags,
             )
             ctx.log(f"Backup concluido com sucesso. ID do snapshot: {snapshot_id}")
-            
-            # Aplicar politica de retencao se ativada
-            if retention_enabled:
+
+            if config.retention_enabled:
                 ctx.log("Aplicando politica de retencao...")
                 client.apply_retention_policy(
-                    keep_hourly=keep_hourly,
-                    keep_daily=keep_daily,
-                    keep_weekly=keep_weekly,
-                    keep_monthly=keep_monthly,
+                    keep_daily=config.keep_daily,
+                    keep_weekly=config.keep_weekly,
+                    keep_monthly=config.keep_monthly,
                     prune=True,
                 )
                 ctx.log("Politica de retencao aplicada.")
             else:
-                ctx.log("Retencao desativada via .env.")
-                
-        except ResticError as e:
-            ctx.log(f"[ERRO] {e}")
+                ctx.log("Retencao desativada via configuracao.")
+
+        except ResticError as exc:
+            ctx.log(f"[ERRO] {exc}")
             sys.exit(1)
-        except Exception as e:
-            ctx.log(f"[FATAL] Erro inesperado: {e}")
+        except Exception as exc:
+            ctx.log(f"[FATAL] Erro inesperado: {exc}")
             sys.exit(1)
-            
+
         ctx.log("=== Fim do backup ===")
 
 

--- a/restic_backup.py
+++ b/restic_backup.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 from services.script import ResticScript
 from services.restic_client import ResticClient, ResticError
@@ -17,7 +16,7 @@ def run_backup() -> None:
         config = ctx.config
         if not config or not config.backup_source_dirs:
             ctx.log("[FATAL] Variaveis obrigatorias ausentes na configuracao")
-            sys.exit(1)
+            raise SystemExit(1)
 
         ctx.log("=== Iniciando backup com Restic ===")
 
@@ -58,10 +57,10 @@ def run_backup() -> None:
 
         except ResticError as exc:
             ctx.log(f"[ERRO] {exc}")
-            sys.exit(1)
+            raise SystemExit(1)
         except Exception as exc:
             ctx.log(f"[FATAL] Erro inesperado: {exc}")
-            sys.exit(1)
+            raise SystemExit(1)
 
         ctx.log("=== Fim do backup ===")
 

--- a/restore_file.py
+++ b/restore_file.py
@@ -6,7 +6,6 @@ from services.restic_client import ResticClient, ResticError
 from services.restore_utils import (
     create_full_restore_structure,
     format_restore_info,
-    get_snapshot_paths_from_data,
 )
 
 

--- a/restore_snapshot.py
+++ b/restore_snapshot.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-import sys
 from services.script import ResticScript
 from services.restic_client import ResticClient, ResticError
 from services.restore_utils import (
@@ -31,7 +30,7 @@ def run_restore_snapshot(snapshot_id: str) -> None:
         config = ctx.config
         if not config or not config.restore_target_dir:
             ctx.log("[FATAL] Diretório de restauração não configurado")
-            sys.exit(1)
+            raise SystemExit(1)
         base_restore_target = config.restore_target_dir
         ctx.log("=== Iniciando restauracao de snapshot com Restic ===")
 


### PR DESCRIPTION
## Summary
- rely on ResticConfig via `ctx.config` for backup and prune scripts
- simplify snapshot and restore utilities to use context-managed credentials
- remove unused imports and variable lookups across scripts
