### PR TITLE
refactor CLI scripts to use ResticConfig

### DIFF
--- a/list_snapshots.py
+++ b/list_snapshots.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import sys
 from datetime import datetime
 import logging

--- a/list_snapshots_with_size.py
+++ b/list_snapshots_with_size.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import sys
 import logging
 

--- a/restic_backup.py
+++ b/restic_backup.py
@@ -1,70 +1,51 @@
-import os
-import sys
 import logging
-from typing import List
+import sys
 
 from services.script import ResticScript
-from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
+from services.restic_client import (
+    ResticClient,
+    ResticError,
+    load_env_and_get_credential_source,
+)
 
 
-def build_args(prefix, items):
-    """Repete ``prefix`` para cada item nao vazio."""
-    return [arg for i in items for arg in (prefix, i.strip()) if i.strip()]
-
-
-def run_backup():
-    """Executa o backup com base nas variaveis do .env e aplica politica de retencao se ativada.
-    
-    Utiliza o ResticClient para executar o backup com retry automatico e tratamento de erros.
-    """
+def run_backup() -> None:
+    """Executa o backup usando configuracao do ``ResticConfig``."""
     credential_source = load_env_and_get_credential_source()
-    
+
     with ResticScript("backup", credential_source=credential_source) as ctx:
-        # Configurar logging
         logging.basicConfig(
             level=logging.INFO,
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
             handlers=[logging.StreamHandler()],
         )
-        
-        # Carregar variaveis de ambiente
-        source_dirs = os.getenv("BACKUP_SOURCE_DIRS", "").split(",")
-        source_dirs = [d.strip() for d in source_dirs if d.strip()]
-        excludes = os.getenv("RESTIC_EXCLUDES", "").split(",")
-        excludes = [e.strip() for e in excludes if e.strip()]
-        tags = os.getenv("RESTIC_TAGS", "").split(",")
-        tags = [t.strip() for t in tags if t.strip()]
 
-        retention_enabled = os.getenv("RETENTION_ENABLED", "true").lower() == "true"
-        keep_hourly = int(os.getenv("RETENTION_KEEP_HOURLY", "0"))
-        keep_daily = int(os.getenv("RETENTION_KEEP_DAILY", "7"))
-        keep_weekly = int(os.getenv("RETENTION_KEEP_WEEKLY", "4"))
-        keep_monthly = int(os.getenv("RETENTION_KEEP_MONTHLY", "6"))
-
-        if not source_dirs:
-            ctx.log("[FATAL] Variaveis obrigatorias ausentes no .env")
+        config = ctx.config
+        if not config or not config.backup_source_dirs:
+            ctx.log("[FATAL] Configuracao de backup ausente ou incompleta")
             sys.exit(1)
+
+        source_dirs = config.backup_source_dirs
+        excludes = config.restic_excludes
+        tags = config.restic_tags
 
         ctx.log("=== Iniciando backup com Restic ===")
 
-        # Criar cliente Restic com retry usando o ambiente já carregado
         client = ResticClient(
             max_attempts=3,
             repository=ctx.repository,
             env=ctx.env,
             provider=ctx.provider,
-            credential_source=credential_source
+            credential_source=credential_source,
         )
-        
+
         try:
-            # Verificar acesso ao repositorio
             ctx.log("🔍 Verificando acesso ao repositorio...")
             if not client.check_repository_access():
                 ctx.log("Nao foi possivel acessar o repositorio. Abortando.")
                 return
             ctx.log("✅ Repositorio acessivel.")
-            
-            # Executar backup
+
             ctx.log(f"Executando backup de: {', '.join(source_dirs)}")
             snapshot_id = client.backup(
                 paths=source_dirs,
@@ -72,28 +53,27 @@ def run_backup():
                 tags=tags,
             )
             ctx.log(f"Backup concluido com sucesso. ID do snapshot: {snapshot_id}")
-            
-            # Aplicar politica de retencao se ativada
-            if retention_enabled:
+
+            if config.retention_enabled:
                 ctx.log("Aplicando politica de retencao...")
                 client.apply_retention_policy(
-                    keep_hourly=keep_hourly,
-                    keep_daily=keep_daily,
-                    keep_weekly=keep_weekly,
-                    keep_monthly=keep_monthly,
+                    keep_daily=config.keep_daily,
+                    keep_weekly=config.keep_weekly,
+                    keep_monthly=config.keep_monthly,
+                    keep_yearly=config.keep_yearly,
                     prune=True,
                 )
                 ctx.log("Politica de retencao aplicada.")
             else:
-                ctx.log("Retencao desativada via .env.")
-                
-        except ResticError as e:
-            ctx.log(f"[ERRO] {e}")
+                ctx.log("Retencao desativada via configuracao.")
+
+        except ResticError as exc:
+            ctx.log(f"[ERRO] {exc}")
             sys.exit(1)
-        except Exception as e:
-            ctx.log(f"[FATAL] Erro inesperado: {e}")
+        except Exception as exc:
+            ctx.log(f"[FATAL] Erro inesperado: {exc}")
             sys.exit(1)
-            
+
         ctx.log("=== Fim do backup ===")
 
 

--- a/restore_file.py
+++ b/restore_file.py
@@ -1,16 +1,16 @@
 import argparse
-import json
 import logging
-import os
-from datetime import datetime
-from pathlib import Path
 
 from services.script import ResticScript
-from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
+from services.restic_client import (
+    ResticClient,
+    ResticError,
+    load_env_and_get_credential_source,
+)
 from services.restore_utils import (
     create_full_restore_structure,
     format_restore_info,
-    get_snapshot_paths_from_data
+    get_snapshot_paths_from_data,
 )
 
 
@@ -41,14 +41,17 @@ def run_restore_file(snapshot_id: str, include_path: str) -> None:
     """
     credential_source = load_env_and_get_credential_source()
     with ResticScript("restore_file", credential_source=credential_source) as ctx:
-        # Configurar logging
         logging.basicConfig(
             level=logging.INFO,
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
             handlers=[logging.StreamHandler()],
         )
-        
-        base_restore_target = os.getenv("RESTORE_TARGET_DIR", "C:\\Restore")
+
+        base_restore_target = (
+            ctx.config.restore_target_dir
+            if ctx.config and ctx.config.restore_target_dir
+            else "C:\\Restore"
+        )
         ctx.log("=== Iniciando restauracao de arquivo com Restic ===")
         
         try:

--- a/restore_snapshot.py
+++ b/restore_snapshot.py
@@ -1,15 +1,16 @@
 import argparse
-import datetime
 import logging
-import os
-from pathlib import Path
+
 from services.script import ResticScript
-from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
+from services.restic_client import (
+    ResticClient,
+    ResticError,
+    load_env_and_get_credential_source,
+)
 from services.restore_utils import (
     create_timestamped_restore_path,
-    create_full_restore_structure,
     format_restore_info,
-    get_snapshot_paths_from_data
+    get_snapshot_paths_from_data,
 )
 
 
@@ -34,14 +35,17 @@ def run_restore_snapshot(snapshot_id: str) -> None:
     credential_source = load_env_and_get_credential_source()
     
     with ResticScript("restore_snapshot", credential_source=credential_source) as ctx:
-        # Configurar logging
         logging.basicConfig(
             level=logging.INFO,
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
             handlers=[logging.StreamHandler()],
         )
-        
-        base_restore_target = os.getenv("RESTORE_TARGET_DIR", "C:\\Restore")
+
+        base_restore_target = (
+            ctx.config.restore_target_dir
+            if ctx.config and ctx.config.restore_target_dir
+            else "C:\\Restore"
+        )
         ctx.log("=== Iniciando restauracao de snapshot com Restic ===")
 
         try:


### PR DESCRIPTION
## Summary
- use ResticConfig fields in backup and prune flows
- derive restore paths from ResticConfig
- clean up duplicate and unused imports across scripts
