### PR TITLE
refactor: unify restic client interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ dry-run:
 ## Mostra estatisticas detalhadas do repositorio
 stats:
 	@echo "Obtendo estatisticas detalhadas..."
-	$(PYTHON_WITH_CREDS); import json; stats = client.get_repository_stats(); print(json.dumps(stats, indent=2))"
+    $(PYTHON_WITH_CREDS); import json; stats = client.get_stats(); print(json.dumps(stats, indent=2))"
 
 ## Aplica politica de retencao (prune)
 prune:

--- a/list_snapshot_files.py
+++ b/list_snapshot_files.py
@@ -36,7 +36,7 @@ def main(snapshot_id: str, output_format: str = "text", output_file: str = None,
             client = ResticClient(max_attempts=3, credential_source=credential_source)
             
             # Listar arquivos do snapshot
-            files_output = client.list_snapshot_files(snapshot_id)
+            files_output = client.list_files(snapshot_id)
             
             if not files_output:
                 ctx.log("Nenhum arquivo encontrado no snapshot.")
@@ -44,11 +44,10 @@ def main(snapshot_id: str, output_format: str = "text", output_file: str = None,
             
             # Processar saida baseado no formato
             if output_format == "json":
-                # files_output ja e uma lista de strings
                 result = {
                     "snapshot_id": snapshot_id,
                     "total_files": len(files_output),
-                    "files": files_output
+                    "files": files_output,
                 }
                 
                 if pretty:
@@ -61,9 +60,9 @@ def main(snapshot_id: str, output_format: str = "text", output_file: str = None,
                     output_content = f"Snapshot ID: {snapshot_id}\n"
                     output_content += f"Total de arquivos: {len(files_output)}\n"
                     output_content += "\nArquivos:\n"
-                    output_content += "\n".join(f"  {file}" for file in files_output)
+                    output_content += "\n".join(f"  {file['path']}" for file in files_output)
                 else:
-                    output_content = "\n".join(files_output)
+                    output_content = "\n".join(f["path"] for f in files_output)
             
             # Salvar em arquivo ou exibir na tela
             if output_file:

--- a/list_snapshots_with_size.py
+++ b/list_snapshots_with_size.py
@@ -53,7 +53,7 @@ def list_snapshots_with_size() -> None:
 
             # Mostrar estatisticas gerais do repositorio
             try:
-                repo_stats = client.get_repository_stats()
+                repo_stats = client.get_stats()
                 if repo_stats and "total_size" in repo_stats:
                     total_repo_bytes = repo_stats.get("total_size", 0)
                     total_repo_gib = total_repo_bytes / (1024 ** 3)

--- a/repository_stats.py
+++ b/repository_stats.py
@@ -36,7 +36,7 @@ def show_repository_stats() -> None:
             )
             
             # Obter estatisticas do repositorio
-            stats = client.get_repository_stats()
+            stats = client.get_stats()
             
             if stats:
                 size_bytes = stats.get("total_size", 0)

--- a/services/restic_common.py
+++ b/services/restic_common.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+
+@dataclass
+class ResticError(Exception):
+    """Erro base para operacoes com o Restic."""
+
+    message: str
+    command: Sequence[str]
+    returncode: Optional[int] = None
+    stdout: Optional[str] = None
+    stderr: Optional[str] = None
+
+    def __str__(self) -> str:  # pragma: no cover - simples
+        return f"{self.message} (codigo: {self.returncode})"
+
+
+class ResticNetworkError(ResticError):
+    """Erro de rede ao acessar o repositorio Restic."""
+
+
+class ResticRepositoryError(ResticError):
+    """Erro relacionado ao repositorio Restic."""
+
+
+class ResticAuthenticationError(ResticError):
+    """Erro de autenticacao no Restic."""
+
+
+class ResticPermissionError(ResticError):
+    """Erro de permissao ao acessar recursos do Restic."""
+
+
+class ResticCommandError(ResticError):
+    """Erro generico na execucao de comandos Restic."""
+
+
+def redact_secrets(text: str) -> str:
+    """Redige senhas e chaves sensiveis de uma string."""
+    patterns = [
+        (r"(RESTIC_PASSWORD=)[^\s,]+", r"\1REDACTED"),
+        (r"(AWS_[^=]+=)[^\s,]+", r"\1REDACTED"),
+        (r"(AZURE_[^=]+=)[^\s,]+", r"\1REDACTED"),
+        (r"(GOOGLE_[^=]+=)[^\s,]+", r"\1REDACTED"),
+        (r"(-p|--password) [^\s]+", r"\1 REDACTED"),
+        (r"(-p|--password-file) [^\s]+", r"\1 REDACTED"),
+    ]
+
+    result = text
+    for pattern, replacement in patterns:
+        result = re.sub(pattern, replacement, result)
+    return result
+
+
+def build_command(repository: Optional[str], *args: str) -> List[str]:
+    """Monta comando para execucao do Restic."""
+    cmd = ["restic"]
+    if repository:
+        cmd.extend(["-r", repository])
+    cmd.extend(args)
+    return cmd
+
+
+def handle_command_error(cmd: Sequence[str], result: subprocess.CompletedProcess[str]) -> None:
+    """Analisa saida de erro de um comando Restic e levanta excecao adequada."""
+    stderr = result.stderr or ""
+    stdout = result.stdout or ""
+    lowered = f"{stderr}\n{stdout}".lower()
+
+    if any(msg in lowered for msg in ["network", "connection", "timeout", "dial tcp"]):
+        raise ResticNetworkError("Erro de rede ao acessar o repositorio", cmd, result.returncode, stdout, stderr)
+    if any(msg in lowered for msg in ["repository not found", "invalid repository", "corrupted"]):
+        raise ResticRepositoryError("Erro no repositorio Restic", cmd, result.returncode, stdout, stderr)
+    if any(msg in lowered for msg in ["authentication", "access denied", "wrong password"]):
+        raise ResticAuthenticationError("Erro de autenticacao", cmd, result.returncode, stdout, stderr)
+    if any(msg in lowered for msg in ["permission", "access is denied", "not permitted"]):
+        raise ResticPermissionError("Erro de permissao", cmd, result.returncode, stdout, stderr)
+    raise ResticCommandError(
+        f"Comando Restic falhou com codigo {result.returncode}",
+        cmd,
+        result.returncode,
+        stdout,
+        stderr,
+    )

--- a/tests/test_restic_client.py
+++ b/tests/test_restic_client.py
@@ -163,10 +163,10 @@ class TestResticClient:
         client.restore_snapshot(snapshot_id="abc123", target_dir="/restore/path")
         mock_successful_subprocess.assert_called_once()
 
-    def test_get_repository_stats_success(self, mock_successful_subprocess) -> None:
+    def test_get_stats_success(self, mock_successful_subprocess) -> None:
         """Testa obtencao de estatisticas do repositorio com sucesso."""
         mock_successful_subprocess.return_value.stdout = json.dumps({"total_size": 1024, "total_file_count": 100})
         client = ResticClient()
-        stats = client.get_repository_stats()
+        stats = client.get_stats()
         assert stats["total_size"] == 1024
         assert stats["total_file_count"] == 100


### PR DESCRIPTION
## Summary
- extract shared restic helpers to new `restic_common`
- refactor sync and async clients to use shared utilities
- align client method names and arguments and update scripts/tests

## Testing
- `pytest` *(fails: STORAGE_PROVIDER invalido, missing env)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b0a7ddf0832ab40b1727e9c8fb5b