### PR TITLE
feat: centralize credential source handling

### DIFF
--- a/check_restic_access.py
+++ b/check_restic_access.py
@@ -2,7 +2,8 @@ import logging
 import sys
 
 from services.script import ResticScript
-from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
+from services.restic_client import ResticClient, ResticError
+from services.env import get_credential_source
 
 
 def check_restic_access() -> None:
@@ -10,7 +11,7 @@ def check_restic_access() -> None:
     
     Utiliza o ResticClient para verificar acesso ao repositorio com retry automatico e tratamento de erros.
     """
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
     with ResticScript("check_restic_access", credential_source=credential_source) as ctx:
         # Configurar logging
         logging.basicConfig(

--- a/examples/async_backup.py
+++ b/examples/async_backup.py
@@ -19,7 +19,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from services.logger import setup_logger
 from services.restic_client_async import ResticClientAsync
-from services.restic_client import load_env_and_get_credential_source
+from services.env import get_credential_source
 
 
 async def backup_directory(client: ResticClientAsync, path: str, tags: Optional[List[str]] = None) -> str:
@@ -66,7 +66,7 @@ async def main():
     )
     
     # Determinar fonte de credenciais e criar cliente
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
     client = ResticClientAsync(credential_source=credential_source)
 
     # Obter diretorios para backup

--- a/examples/timestamped_restore.py
+++ b/examples/timestamped_restore.py
@@ -14,7 +14,8 @@ from datetime import datetime
 # Adicionar o diretório pai ao path para importar os módulos
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
+from services.restic_client import ResticClient, ResticError
+from services.env import get_credential_source
 from services.restore_utils import (
     create_timestamped_restore_path,
     create_full_restore_structure,
@@ -31,7 +32,7 @@ def demonstrate_timestamped_restore():
     print("=" * 70)
     
     try:
-        credential_source = load_env_and_get_credential_source()
+        credential_source = get_credential_source()
 
         # Criar cliente Restic
         client = ResticClient(credential_source=credential_source)

--- a/list_snapshot_files.py
+++ b/list_snapshot_files.py
@@ -5,7 +5,8 @@ import sys
 from pathlib import Path
 
 from services.script import ResticScript
-from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
+from services.restic_client import ResticClient, ResticError
+from services.env import get_credential_source
 
 
 def parse_args() -> argparse.Namespace:
@@ -20,7 +21,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main(snapshot_id: str, output_format: str = "text", output_file: str = None, pretty: bool = False) -> None:
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
     with ResticScript("list_snapshot_files", credential_source=credential_source) as ctx:
         # Configurar logging
         logging.basicConfig(

--- a/list_snapshots.py
+++ b/list_snapshots.py
@@ -6,7 +6,8 @@ import sys
 from datetime import datetime
 import logging
 from services.script import ResticScript
-from services.restic_client import ResticClient, load_env_and_get_credential_source, ResticError
+from services.restic_client import ResticClient, ResticError
+from services.env import get_credential_source
 
 
 def list_snapshots() -> None:
@@ -14,7 +15,7 @@ def list_snapshots() -> None:
     
     Utiliza o ResticClient para obter a lista de snapshots com retry automatico e tratamento de erros.
     """
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
 
     with ResticScript("list_snapshots", credential_source=credential_source) as ctx:
         # Configurar logging

--- a/list_snapshots_with_size.py
+++ b/list_snapshots_with_size.py
@@ -6,7 +6,8 @@ import sys
 import logging
 
 from services.script import ResticScript
-from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
+from services.restic_client import ResticClient, ResticError
+from services.env import get_credential_source
 
 
 def list_snapshots_with_size() -> None:
@@ -14,7 +15,7 @@ def list_snapshots_with_size() -> None:
     
     Utiliza o ResticClient para obter snapshots e seus tamanhos com retry automatico e tratamento de erros.
     """
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
     with ResticScript("list_snapshots_with_size", credential_source=credential_source) as ctx:
         # Configurar logging
         logging.basicConfig(

--- a/main.py
+++ b/main.py
@@ -11,7 +11,8 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
-from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
+from services.restic_client import ResticClient, ResticError
+from services.env import get_credential_source
 
 
 def setup_logging():
@@ -29,7 +30,7 @@ def setup_logging():
 def main():
     """Funcao principal que demonstra o uso do ResticClient."""
     # Carregar variaveis de ambiente
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
     
     # Configurar logging
     os.makedirs("logs", exist_ok=True)

--- a/manual_prune.py
+++ b/manual_prune.py
@@ -5,8 +5,8 @@ from services.script import ResticScript
 from services.restic_client import (
     ResticClient,
     ResticError,
-    load_env_and_get_credential_source,
 )
+from services.env import get_credential_source
 
 
 def main() -> None:
@@ -14,7 +14,7 @@ def main() -> None:
     
     Utiliza o ResticClient para aplicar politicas de retencao com retry automatico e tratamento de erros.
     """
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
     with ResticScript("manual_prune", credential_source=credential_source) as ctx:
         # Configurar logging
         logging.basicConfig(

--- a/repository_stats.py
+++ b/repository_stats.py
@@ -6,7 +6,8 @@ import logging
 import sys
 
 from services.script import ResticScript
-from services.restic_client import ResticClient, ResticError, load_env_and_get_credential_source
+from services.restic_client import ResticClient, ResticError
+from services.env import get_credential_source
 
 
 def show_repository_stats() -> None:
@@ -14,7 +15,7 @@ def show_repository_stats() -> None:
     
     Utiliza o ResticClient para obter estatisticas com retry automatico e tratamento de erros.
     """
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
     with ResticScript("repository_stats", credential_source=credential_source) as ctx:
         # Configurar logging
         logging.basicConfig(

--- a/restic_backup.py
+++ b/restic_backup.py
@@ -5,13 +5,13 @@ from services.script import ResticScript
 from services.restic_client import (
     ResticClient,
     ResticError,
-    load_env_and_get_credential_source,
 )
+from services.env import get_credential_source
 
 
 def run_backup() -> None:
     """Executa o backup usando configuracao do ``ResticConfig``."""
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
 
     with ResticScript("backup", credential_source=credential_source) as ctx:
         logging.basicConfig(

--- a/restore_file.py
+++ b/restore_file.py
@@ -5,8 +5,8 @@ from services.script import ResticScript
 from services.restic_client import (
     ResticClient,
     ResticError,
-    load_env_and_get_credential_source,
 )
+from services.env import get_credential_source
 from services.restore_utils import (
     create_full_restore_structure,
     format_restore_info,
@@ -39,7 +39,7 @@ def run_restore_file(snapshot_id: str, include_path: str) -> None:
     include_path : str
         Caminho do arquivo ou diretorio a ser restaurado
     """
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
     with ResticScript("restore_file", credential_source=credential_source) as ctx:
         logging.basicConfig(
             level=logging.INFO,

--- a/restore_snapshot.py
+++ b/restore_snapshot.py
@@ -5,8 +5,8 @@ from services.script import ResticScript
 from services.restic_client import (
     ResticClient,
     ResticError,
-    load_env_and_get_credential_source,
 )
+from services.env import get_credential_source
 from services.restore_utils import (
     create_timestamped_restore_path,
     format_restore_info,
@@ -32,7 +32,7 @@ def run_restore_snapshot(snapshot_id: str) -> None:
     snapshot_id : str
         ID do snapshot a ser restaurado ou "latest" para o mais recente
     """
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
     
     with ResticScript("restore_snapshot", credential_source=credential_source) as ctx:
         logging.basicConfig(

--- a/safestic/cli.py
+++ b/safestic/cli.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from services.restic_client import (
     ResticClient,
     ResticError,
-    load_env_and_get_credential_source,
 )
+from services.env import get_credential_source
 from services.restic import load_restic_config
 from services.script import ResticScript
 
@@ -29,7 +29,7 @@ def cmd_list(args: argparse.Namespace) -> None:
 
 def cmd_init(args: argparse.Namespace) -> None:
     """Initialize repository if needed."""
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
     with ResticScript("init", credential_source=credential_source) as ctx:
         client = ResticClient(
             repository=ctx.repository,
@@ -51,7 +51,7 @@ def cmd_init(args: argparse.Namespace) -> None:
 
 def cmd_dry_run(args: argparse.Namespace) -> None:
     """Display configured backup paths and check their existence."""
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
     config = load_restic_config(credential_source)
     print("Configuracao de backup:")
     print(f"Diretorios: {config.backup_source_dirs}")

--- a/scripts/check_credentials.py
+++ b/scripts/check_credentials.py
@@ -20,9 +20,9 @@ try:
 except ImportError:
     get_credential = None
 
-from services.restic_client import load_env_and_get_credential_source
+from services.env import get_credential_source
 
-credential_source = load_env_and_get_credential_source().lower()
+credential_source = get_credential_source().lower()
 
 
 def check_restic_password() -> Tuple[bool, str]:

--- a/scripts/check_mount_support.py
+++ b/scripts/check_mount_support.py
@@ -11,8 +11,8 @@ from services.script import ResticScript
 from services.restic_client import (
     ResticClient,
     ResticError,
-    load_env_and_get_credential_source,
 )
+from services.env import get_credential_source
 
 
 def check_winfsp() -> bool:
@@ -31,7 +31,7 @@ def check_winfsp() -> bool:
 
 
 def main() -> int:
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
 
     with ResticScript("check_mount_support", credential_source=credential_source) as ctx:
         try:

--- a/scripts/compare_configs.py
+++ b/scripts/compare_configs.py
@@ -12,6 +12,7 @@ import json
 import platform
 from pathlib import Path
 from dotenv import load_dotenv
+from services.env import get_credential_source
 
 def get_system_info():
     """Coleta informações do sistema."""
@@ -51,7 +52,7 @@ def get_env_variables():
     
     env_vars = {}
     for var in important_vars:
-        value = os.getenv(var)
+        value = get_credential_source() if var == "CREDENTIAL_SOURCE" else os.getenv(var)
         if value:
             # Mascarar credenciais sensíveis
             if any(sensitive in var.upper() for sensitive in ["PASSWORD", "KEY", "SECRET"]):

--- a/scripts/diagnose_azure_linux.py
+++ b/scripts/diagnose_azure_linux.py
@@ -12,7 +12,7 @@ import subprocess
 import json
 from pathlib import Path
 
-from services.restic_client import load_env_and_get_credential_source
+from services.env import get_credential_source
 
 # Importar load_restic_env para carregar configurações como no Windows
 try:
@@ -104,7 +104,7 @@ def check_azure_credentials():
     
     if HAS_RESTIC_SERVICE:
         try:
-            credential_source = load_env_and_get_credential_source()
+            credential_source = get_credential_source()
             
             print(f"🔧 Usando load_restic_env com credential_source='{credential_source}' (como no Windows)")
             repository, env_vars, provider = load_restic_env(credential_source)
@@ -116,7 +116,7 @@ def check_azure_credentials():
     
     if not HAS_RESTIC_SERVICE or not repository:
         # Fallback para carregamento manual
-        load_env_and_get_credential_source()
+        get_credential_source()
         env_vars = dict(os.environ)
         repository = os.getenv("RESTIC_REPOSITORY")
         provider = os.getenv("STORAGE_PROVIDER")
@@ -130,7 +130,7 @@ def check_azure_credentials():
         "AZURE_ACCOUNT_KEY": env_vars.get("AZURE_ACCOUNT_KEY"),
         "STORAGE_PROVIDER": provider or env_vars.get("STORAGE_PROVIDER"),
         "STORAGE_BUCKET": env_vars.get("STORAGE_BUCKET"),
-        "CREDENTIAL_SOURCE": env_vars.get("CREDENTIAL_SOURCE", "env")
+        "CREDENTIAL_SOURCE": env_vars.get("CREDENTIAL_SOURCE", get_credential_source())
     }
     
     print("Variáveis de ambiente:")
@@ -167,14 +167,14 @@ def test_azure_connectivity():
     
     if HAS_RESTIC_SERVICE:
         try:
-            credential_source = load_env_and_get_credential_source()
+            credential_source = get_credential_source()
             repository, env_vars, provider = load_restic_env(credential_source)
         except Exception:
-            load_env_and_get_credential_source()
+            get_credential_source()
             env_vars = dict(os.environ)
             repository = os.getenv("RESTIC_REPOSITORY")
     else:
-        load_env_and_get_credential_source()
+        get_credential_source()
         env_vars = dict(os.environ)
         repository = os.getenv("RESTIC_REPOSITORY")
     

--- a/scripts/forget_snapshots.py
+++ b/scripts/forget_snapshots.py
@@ -10,12 +10,12 @@ from services.script import ResticScript
 from services.restic_client import (
     ResticClient,
     ResticError,
-    load_env_and_get_credential_source,
 )
+from services.env import get_credential_source
 
 
 def main() -> int:
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
 
     with ResticScript("forget_snapshots", credential_source=credential_source) as ctx:
         try:

--- a/scripts/health_check.py
+++ b/scripts/health_check.py
@@ -16,7 +16,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from services.logger import setup_logger
 from services.restic import load_restic_config, load_restic_env
-from services.restic_client import ResticClient, load_env_and_get_credential_source
+from services.restic_client import ResticClient
+from services.env import get_credential_source
 
 logger = setup_logger(__name__)
 
@@ -122,7 +123,7 @@ class HealthChecker:
     def check_restic_config(self):
         """Verifica configuracao do Restic"""
         try:
-            credential_source = load_env_and_get_credential_source()
+            credential_source = get_credential_source()
             config = load_restic_config(credential_source)
             
             # Verificar variaveis essenciais
@@ -155,7 +156,7 @@ class HealthChecker:
     def check_restic_repository(self):
         """Verifica acesso ao repositorio Restic"""
         try:
-            credential_source = load_env_and_get_credential_source()
+            credential_source = get_credential_source()
             repository, env, provider = load_restic_env(credential_source)
             
             client = ResticClient(

--- a/scripts/mount_repo.py
+++ b/scripts/mount_repo.py
@@ -12,8 +12,8 @@ from services.script import ResticScript
 from services.restic_client import (
     ResticClient,
     ResticError,
-    load_env_and_get_credential_source,
 )
+from services.env import get_credential_source
 
 
 def check_fuse_support() -> tuple[bool, str | None]:
@@ -53,7 +53,7 @@ def create_mount_point(mount_path: str) -> bool:
 
 
 def main() -> int:
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
 
     with ResticScript("mount_repo", credential_source=credential_source) as ctx:
         try:

--- a/scripts/rebuild_index.py
+++ b/scripts/rebuild_index.py
@@ -9,13 +9,13 @@ from services.script import ResticScript
 from services.restic_client import (
     ResticClient,
     ResticError,
-    load_env_and_get_credential_source,
 )
+from services.env import get_credential_source
 
 
 def main() -> int:
     read_all_packs = "--read-all-packs" in sys.argv or "--full" in sys.argv
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
 
     with ResticScript("rebuild_index", credential_source=credential_source) as ctx:
         try:

--- a/scripts/repair_repo.py
+++ b/scripts/repair_repo.py
@@ -9,8 +9,8 @@ from services.script import ResticScript
 from services.restic_client import (
     ResticClient,
     ResticError,
-    load_env_and_get_credential_source,
 )
+from services.env import get_credential_source
 
 
 def main() -> int:
@@ -22,7 +22,7 @@ def main() -> int:
     elif "--packs" in sys.argv:
         repair_type = "packs"
 
-    credential_source = load_env_and_get_credential_source()
+    credential_source = get_credential_source()
 
     with ResticScript("repair_repo", credential_source=credential_source) as ctx:
         try:

--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 
 from services.credentials import get_credential
-from services.restic_client import load_env_and_get_credential_source
+from services.env import get_credential_source
 
 credential_source = "env"
 
@@ -22,7 +22,7 @@ def load_env_file():
         print("DICA: Execute: cp .env.example .env")
         return False
 
-    credential_source = load_env_and_get_credential_source().lower()
+    credential_source = get_credential_source().lower()
     print("OK: Arquivo .env carregado")
     return True
 

--- a/scripts/validate_setup.py
+++ b/scripts/validate_setup.py
@@ -16,7 +16,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from services.logger import setup_logger
 from services.restic import load_restic_config, load_restic_env
-from services.restic_client import ResticClient, load_env_and_get_credential_source
+from services.restic_client import ResticClient
+from services.env import get_credential_source
 
 logger = setup_logger(__name__)
 
@@ -175,7 +176,7 @@ class SetupValidator:
         print("\n Validando configuracao Restic...")
         
         try:
-            credential_source = load_env_and_get_credential_source()
+            credential_source = get_credential_source()
             config = load_restic_config(credential_source)
             
             # Verificar configuracoes criticas
@@ -235,7 +236,7 @@ class SetupValidator:
         print("\n Validando acesso ao repositorio...")
         
         try:
-            credential_source = load_env_and_get_credential_source()
+            credential_source = get_credential_source()
             repository, env, provider = load_restic_env(credential_source)
             
             client = ResticClient(

--- a/services/env.py
+++ b/services/env.py
@@ -1,0 +1,19 @@
+"""Utility functions for environment configuration."""
+
+from __future__ import annotations
+
+import os
+from dotenv import load_dotenv
+
+
+def get_credential_source() -> str:
+    """Load ``.env`` and return configured ``CREDENTIAL_SOURCE``.
+
+    Returns
+    -------
+    str
+        Value of ``CREDENTIAL_SOURCE`` from environment (default ``"env"``).
+    """
+    load_dotenv()
+    return os.getenv("CREDENTIAL_SOURCE", "env")
+

--- a/services/restic_client.py
+++ b/services/restic_client.py
@@ -29,6 +29,7 @@ from .restic_common import (
     build_restic_command,
     redact_secrets,
 )
+from .env import get_credential_source
 
 # Tipo generico para o resultado de funcoes com retry
 T = TypeVar("T")
@@ -845,18 +846,5 @@ class ResticClient:
 
 
 def load_env_and_get_credential_source() -> str:
-    """Carrega o arquivo .env e retorna o credential_source configurado.
-    
-    Esta função centraliza o carregamento do ambiente para evitar duplicação
-    de código nos comandos do Makefile.
-    
-    Returns
-    -------
-    str
-        O valor de CREDENTIAL_SOURCE do arquivo .env (padrão: 'env')
-    """
-    import os
-    from dotenv import load_dotenv
-    
-    load_dotenv()
-    return os.getenv('CREDENTIAL_SOURCE', 'env')
+    """Backward compatible wrapper for :func:`get_credential_source`."""
+    return get_credential_source()

--- a/services/script.py
+++ b/services/script.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, TextIO, Union, cast
 
 from .restic import load_restic_env, load_restic_config, ResticConfig
+from .env import get_credential_source
 from .logger import create_log_file, log as _log, run_cmd as _run_cmd, setup_logger, redact_secrets
 
 
@@ -45,9 +46,7 @@ class ResticScript:
         self.log_dir = log_dir or os.getenv("LOG_DIR", "logs")
         # Se credential_source não for especificado, obter do .env
         if credential_source is None:
-            from dotenv import load_dotenv
-            load_dotenv()
-            credential_source = os.getenv("CREDENTIAL_SOURCE", "env")
+            credential_source = get_credential_source()
         self.credential_source = credential_source
         self.log_level = log_level
         self.repository: str = ""

--- a/tests/test_azure_keyring.py
+++ b/tests/test_azure_keyring.py
@@ -27,6 +27,7 @@ except ImportError:
 try:
     from services.credentials import get_credential, CredentialManager
     from services.restic import load_restic_config
+    from services.env import get_credential_source
 except ImportError as e:
     print(f"❌ Erro ao importar módulos SafeStic: {e}")
     sys.exit(1)
@@ -72,18 +73,18 @@ def test_env_loading():
     # Verificar variáveis importantes
     important_vars = [
         'STORAGE_PROVIDER',
-        'STORAGE_BUCKET', 
+        'STORAGE_BUCKET',
         'CREDENTIAL_SOURCE'
     ]
-    
+
     for var in important_vars:
-        value = os.getenv(var)
+        value = get_credential_source() if var == 'CREDENTIAL_SOURCE' else os.getenv(var)
         if value:
             print(f"✅ {var}: {value}")
         else:
             print(f"❌ {var}: Não definida")
-    
-    credential_source = os.getenv('CREDENTIAL_SOURCE', 'env')
+
+    credential_source = get_credential_source()
     return credential_source
 
 def test_keyring_access():
@@ -130,7 +131,7 @@ def test_azure_credentials():
     print("\n🔍 TESTE DE CREDENCIAIS AZURE")
     print("=" * 50)
     
-    credential_source = os.getenv('CREDENTIAL_SOURCE', 'env')
+    credential_source = get_credential_source()
     print(f"Fonte de credenciais: {credential_source}")
     
     azure_creds = [
@@ -159,7 +160,7 @@ def test_restic_config():
     print("\n🔍 TESTE DE CONFIGURAÇÃO RESTIC")
     print("=" * 50)
     
-    credential_source = os.getenv('CREDENTIAL_SOURCE', 'env')
+    credential_source = get_credential_source()
     
     try:
         config = load_restic_config(credential_source)

--- a/tests/test_keyring_credential_source.py
+++ b/tests/test_keyring_credential_source.py
@@ -8,6 +8,7 @@ import os
 from dotenv import load_dotenv
 from services.restic import load_restic_config
 from services.credentials import get_credential
+from services.env import get_credential_source
 
 def test_credential_source():
     """Testa se o CREDENTIAL_SOURCE está sendo lido corretamente"""
@@ -17,7 +18,7 @@ def test_credential_source():
     load_dotenv()
     
     # Verificar CREDENTIAL_SOURCE
-    credential_source = os.getenv('CREDENTIAL_SOURCE', 'env')
+    credential_source = get_credential_source()
     print(f"✓ CREDENTIAL_SOURCE detectado: {credential_source}")
     
     # Testar carregamento da senha


### PR DESCRIPTION
## Summary
- add `get_credential_source` helper in `services/env`
- use `get_credential_source` across scripts instead of manual env loading
- integrate helper into `ResticScript`
