### PR TITLE
centralize logging via ResticScript

### DIFF
--- a/COMANDOS.md
+++ b/COMANDOS.md
@@ -16,6 +16,11 @@ Para ver a lista completa de comandos:
 make help
 ```
 
+## 📝 Logging
+
+Os comandos CLI ja configuram o logging automaticamente via `ResticScript`. Use `ctx.log(...)` para registrar mensagens e evite
+chamar `logging.basicConfig` ou outras configuracoes globais.
+
 ## 🔑 Configuração de Senhas (RESTIC_PASSWORD)
 
 O `RESTIC_PASSWORD` é **obrigatório** para criptografar seus backups. O Safestic oferece várias formas seguras de configurá-lo:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Safestic e uma ferramenta de backup automatizada que utiliza o Restic para criar
 
 ---
 
+## 📋 Logging Estruturado
+
+Todos os scripts CLI utilizam o gerenciador de contexto `ResticScript`, que prepara o arquivo de log e configura a saida no formato JSON.
+Para registrar mensagens use apenas `ctx.log(...)` dentro desse contexto. Nao e necessario chamar `logging.basicConfig` ou qualquer
+configuracao global de logging.
+
+---
+
 ## 🚀 Funcionalidades
 
 - Backup incremental, seguro e criptografado com Restic

--- a/check_restic_access.py
+++ b/check_restic_access.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 
 from services.script import ResticScript
@@ -13,13 +12,6 @@ def check_restic_access() -> None:
     """
     credential_source = get_credential_source()
     with ResticScript("check_restic_access", credential_source=credential_source) as ctx:
-        # Configurar logging
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            handlers=[logging.StreamHandler()],
-        )
-        
         ctx.log("=== Verificando acesso ao repositorio Restic ===")
         restic_password = ctx.env.get("RESTIC_PASSWORD")
 

--- a/list_snapshot_files.py
+++ b/list_snapshot_files.py
@@ -1,6 +1,5 @@
 import argparse
 import json
-import logging
 import sys
 from pathlib import Path
 
@@ -23,13 +22,6 @@ def parse_args() -> argparse.Namespace:
 def main(snapshot_id: str, output_format: str = "text", output_file: str = None, pretty: bool = False) -> None:
     credential_source = get_credential_source()
     with ResticScript("list_snapshot_files", credential_source=credential_source) as ctx:
-        # Configurar logging
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            handlers=[logging.StreamHandler()],
-        )
-        
         ctx.log(f"Listando arquivos do snapshot '{snapshot_id}'...")
         
         try:

--- a/list_snapshots.py
+++ b/list_snapshots.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import sys
 from datetime import datetime
-import logging
 from services.script import ResticScript
 from services.restic_client import ResticClient, ResticError
 from services.env import get_credential_source
@@ -18,13 +17,6 @@ def list_snapshots() -> None:
     credential_source = get_credential_source()
 
     with ResticScript("list_snapshots", credential_source=credential_source) as ctx:
-        # Configurar logging
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            handlers=[logging.StreamHandler()],
-        )
-        
         ctx.log(f"Listando snapshots do repositorio: {ctx.repository}\n")
 
         try:

--- a/list_snapshots_with_size.py
+++ b/list_snapshots_with_size.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-import logging
 
 from services.script import ResticScript
 from services.restic_client import ResticClient, ResticError
@@ -17,13 +16,6 @@ def list_snapshots_with_size() -> None:
     """
     credential_source = get_credential_source()
     with ResticScript("list_snapshots_with_size", credential_source=credential_source) as ctx:
-        # Configurar logging
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            handlers=[logging.StreamHandler()],
-        )
-        
         try:
             # Criar cliente Restic com retry usando o ambiente já carregado
             client = ResticClient(

--- a/manual_prune.py
+++ b/manual_prune.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 
 from services.script import ResticScript
@@ -16,13 +15,6 @@ def main() -> None:
     """
     credential_source = get_credential_source()
     with ResticScript("manual_prune", credential_source=credential_source) as ctx:
-        # Configurar logging
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            handlers=[logging.StreamHandler()],
-        )
-        
         ctx.log("=== Iniciando limpeza manual de snapshots com Restic ===")
 
         try:

--- a/repository_stats.py
+++ b/repository_stats.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 import sys
 
 from services.script import ResticScript
@@ -17,13 +16,6 @@ def show_repository_stats() -> None:
     """
     credential_source = get_credential_source()
     with ResticScript("repository_stats", credential_source=credential_source) as ctx:
-        # Configurar logging
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            handlers=[logging.StreamHandler()],
-        )
-        
         ctx.log(f"Obtendo estatisticas gerais do repositorio: {ctx.repository}\n")
 
         try:

--- a/restic_backup.py
+++ b/restic_backup.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 
 from services.script import ResticScript
@@ -14,12 +13,6 @@ def run_backup() -> None:
     credential_source = get_credential_source()
 
     with ResticScript("backup", credential_source=credential_source) as ctx:
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            handlers=[logging.StreamHandler()],
-        )
-
         config = ctx.config
         if not config or not config.backup_source_dirs:
             ctx.log("[FATAL] Configuracao de backup ausente ou incompleta")

--- a/restore_file.py
+++ b/restore_file.py
@@ -1,5 +1,4 @@
 import argparse
-import logging
 
 from services.script import ResticScript
 from services.restic_client import (
@@ -41,12 +40,6 @@ def run_restore_file(snapshot_id: str, include_path: str) -> None:
     """
     credential_source = get_credential_source()
     with ResticScript("restore_file", credential_source=credential_source) as ctx:
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            handlers=[logging.StreamHandler()],
-        )
-
         base_restore_target = (
             ctx.config.restore_target_dir
             if ctx.config and ctx.config.restore_target_dir

--- a/restore_snapshot.py
+++ b/restore_snapshot.py
@@ -1,5 +1,4 @@
 import argparse
-import logging
 
 from services.script import ResticScript
 from services.restic_client import (
@@ -35,12 +34,6 @@ def run_restore_snapshot(snapshot_id: str) -> None:
     credential_source = get_credential_source()
     
     with ResticScript("restore_snapshot", credential_source=credential_source) as ctx:
-        logging.basicConfig(
-            level=logging.INFO,
-            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-            handlers=[logging.StreamHandler()],
-        )
-
         base_restore_target = (
             ctx.config.restore_target_dir
             if ctx.config and ctx.config.restore_target_dir


### PR DESCRIPTION
## Summary
- remove redundant logging.basicConfig calls in CLI scripts
- simplify ResticScript to rely on built-in structured logger
- document logging usage guidelines

