### PR TITLE
Use python3 by default in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 .PHONY: backup list init dry-run
 
-backup: ; python -m safestic.cli backup
-list: ; python -m safestic.cli list
-init: ; python -m safestic.cli init
-dry-run: ; python -m safestic.cli dry-run
+# Use the system's default Python interpreter, defaulting to python3 when
+# `python` is not available (common on many Linux distributions).
+PYTHON ?= python3
+
+backup: ; $(PYTHON) -m safestic.cli backup
+list: ; $(PYTHON) -m safestic.cli list
+init: ; $(PYTHON) -m safestic.cli init
+dry-run: ; $(PYTHON) -m safestic.cli dry-run


### PR DESCRIPTION
## Summary
- default Makefile to use python3 when `python` is missing

