### PR TITLE
Use local venv for Safestic CLI commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
 .PHONY: backup list init dry-run
 
-# Use the system's default Python interpreter, defaulting to python3 when
-# `python` is not available (common on many Linux distributions).
-PYTHON ?= python3
+# Determine the appropriate Python interpreter. If a local virtual
+# environment exists in .venv, prefer its Python executable. Otherwise,
+# fall back to the system's default python3 (or python).
+VENV ?= .venv
+PYTHON := $(shell \
+    if [ -f "$(VENV)/bin/python" ]; then echo "$(VENV)/bin/python"; \
+    elif command -v python3 >/dev/null 2>&1; then command -v python3; \
+    else command -v python; fi)
 
-backup: ; $(PYTHON) -m safestic.cli backup
-list: ; $(PYTHON) -m safestic.cli list
-init: ; $(PYTHON) -m safestic.cli init
-dry-run: ; $(PYTHON) -m safestic.cli dry-run
+# Reusable CLI command to avoid repetition across targets.
+CLI = $(PYTHON) -m safestic.cli
+
+COMMANDS := backup list init dry-run
+
+$(COMMANDS):
+	$(CLI) $@


### PR DESCRIPTION
## Summary
- detect and use `.venv` python interpreter in Makefile
- avoid command duplication by centralizing Safestic CLI invocations

